### PR TITLE
GPU hackathon gradient closure work

### DIFF
--- a/core/zero/gkyl_rect_decomp.h
+++ b/core/zero/gkyl_rect_decomp.h
@@ -171,6 +171,18 @@ void gkyl_create_ranges(const struct gkyl_range *inrange,
   const int *nghost, struct gkyl_range *ext_range, struct gkyl_range *range);
 
 /**
+ * Create range and extended vertex ranges from given range and ghost-cell
+ * data. The range is a sub-range of the extended range.
+ *
+ * @param inrange Input range to use
+ * @param nghost Number of ghost-cells in each direction
+ * @param ext_range On output, extended range spanning inrange+ghost-cells
+ * @param range On output, range same as inrange, but sub-range of ext_range.
+ */
+void gkyl_create_vertex_ranges(const struct gkyl_range *inrange,
+  const int *nghost, struct gkyl_range *ext_range, struct gkyl_range *range);
+
+/**
  * Return the cuts used to create the the decomposition object.
  * 
  * @param decomp Decomposition object.

--- a/core/zero/rect_decomp.c
+++ b/core/zero/rect_decomp.c
@@ -428,6 +428,24 @@ gkyl_create_ranges(const struct gkyl_range *inrange,
 }
 
 void
+gkyl_create_vertex_ranges(const struct gkyl_range *inrange,
+  const int *nghost, struct gkyl_range *ext_range, struct gkyl_range *range)
+{
+  int lower_ext[GKYL_MAX_DIM], upper_ext[GKYL_MAX_DIM];
+  int lower[GKYL_MAX_DIM], upper[GKYL_MAX_DIM];
+
+  for (int i=0; i<inrange->ndim; ++i) {
+    lower_ext[i] = inrange->lower[i] - nghost[i];
+    upper_ext[i] = inrange->upper[i] + 1 + nghost[i];
+
+    lower[i] = inrange->lower[i];
+    upper[i] = inrange->upper[i] + 1;
+  }
+  gkyl_range_init(ext_range, inrange->ndim, lower_ext, upper_ext);
+  gkyl_sub_range_init(range, ext_range, lower, upper);  
+}
+
+void
 gkyl_rect_decomp_get_cuts(struct gkyl_rect_decomp* decomp, int* cuts)
 {
   int ndim = decomp->ndim;

--- a/moments/apps/gkyl_moment_priv.h
+++ b/moments/apps/gkyl_moment_priv.h
@@ -451,8 +451,8 @@ void mhd_src_release(const struct mhd_src *src);
 
 // update sources: 'nstrang' is 0 for the first Strang step and 1 for
 // the second step
-void moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
-  int nstrang, double tcurr, double dt);
+struct gkyl_update_status moment_coupling_update(gkyl_moment_app *app,
+  struct moment_coupling *src, int nstrang, double tcurr, double dt);
 
 // Release coupling sources
 void moment_coupling_release(const struct gkyl_moment_app *app,

--- a/moments/apps/mom_coupling.c
+++ b/moments/apps/mom_coupling.c
@@ -145,6 +145,7 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
         .k0 = app->species[i].k0,
         .cfl = app->cfl,
         .comm = app->comm,
+        .use_gpu = app->use_gpu,
       };
       src->grad_closure_slvr[i] = gkyl_ten_moment_grad_closure_new(grad_closure_inp);
     }

--- a/moments/apps/mom_coupling.c
+++ b/moments/apps/mom_coupling.c
@@ -135,13 +135,11 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
   gkyl_create_vertex_ranges(&app->local, ghost, &src->non_ideal_local_ext,
     &src->non_ideal_local);
 
-  // In Gradient-closure case, non-ideal variables are 10 heat flux tensor components
-  for (int n=0;  n<app->num_species; ++n)
-    src->non_ideal_vars[n] = mkarr(false, 10, src->non_ideal_local_ext.volume);
-
   // check if gradient-closure is present
   for (int i=0; i<app->num_species; ++i) {
     if (app->species[i].eqn_type == GKYL_EQN_TEN_MOMENT && app->species[i].has_grad_closure) {
+      int nadj[3] = { 1, 4, 8 }; // cells adjacent to a vertex
+      src->non_ideal_vars[i] = mkarr(false, nadj[app->ndim - 1]*10, src->non_ideal_local_ext.volume);
       struct gkyl_ten_moment_grad_closure_inp grad_closure_inp = {
         .grid = &app->grid,
         .k0 = app->species[i].k0,
@@ -162,6 +160,7 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
       .coll_fac = app->coll_fac == 0 ? 1.0 : app->coll_fac,
     };
     for (int i=0; i<app->num_species; ++i) {
+      src->non_ideal_vars[i] = mkarr(false, 10, src->non_ideal_local_ext.volume);
       // Braginskii coefficients depend on pressure and coefficient to obtain
       // pressure is different for different equation systems (gasGamma, vt, Tr(P))
       double p_fac = 1.0;

--- a/moments/apps/mom_coupling.c
+++ b/moments/apps/mom_coupling.c
@@ -132,7 +132,8 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
   int ghost[3] = { 1, 1, 1 };
   // create non-ideal local extended range from local range
   // has one additional cell in each direction because non-ideal variables are stored at cell vertices
-  gkyl_create_ranges(&app->local, ghost, &src->non_ideal_local_ext, &src->non_ideal_local);
+  gkyl_create_vertex_ranges(&app->local, ghost, &src->non_ideal_local_ext,
+    &src->non_ideal_local);
 
   // In Gradient-closure case, non-ideal variables are 10 heat flux tensor components
   for (int n=0;  n<app->num_species; ++n)
@@ -144,6 +145,8 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
       struct gkyl_ten_moment_grad_closure_inp grad_closure_inp = {
         .grid = &app->grid,
         .k0 = app->species[i].k0,
+        .cfl = app->cfl,
+        .comm = app->comm,
       };
       src->grad_closure_slvr[i] = gkyl_ten_moment_grad_closure_new(grad_closure_inp);
     }
@@ -182,7 +185,7 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
 
 // update sources: 'nstrang' is 0 for the first Strang step and 1 for
 // the second step
-void
+struct gkyl_update_status
 moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
   int nstrang, double tcurr, double dt)
 {
@@ -191,6 +194,9 @@ moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
   const struct gkyl_array *app_accels[GKYL_MAX_SPECIES];
   const struct gkyl_array *pr_rhs_const[GKYL_MAX_SPECIES];
   const struct gkyl_array *nT_sources[GKYL_MAX_SPECIES];
+
+  double dt_suggested = DBL_MAX;
+  struct gkyl_ten_moment_grad_closure_status stat;
 
   for (int i=0; i<app->num_species; ++i) {
     fluids[i] = app->species[i].f[sidx[nstrang]];
@@ -203,16 +209,24 @@ moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
     if (app->species[i].eqn_type == GKYL_EQN_TEN_MOMENT && app->species[i].has_grad_closure) {
       // non-ideal variables defined on an extended range with one additional "cell" in each direction
       // this additional cell accounts for the fact that non-ideal variables are stored at cell vertices
-      gkyl_ten_moment_grad_closure_advance(src->grad_closure_slvr[i],
-        &src->non_ideal_local_ext, &app->local,
+      stat = gkyl_ten_moment_grad_closure_advance(src->grad_closure_slvr[i],
+        &src->non_ideal_local, &app->local,
         app->species[i].f[sidx[nstrang]], app->field.f[sidx[nstrang]],
-        src->non_ideal_cflrate[i], src->non_ideal_vars[i], src->pr_rhs[i]);
+        src->non_ideal_cflrate[i], dt, src->non_ideal_vars[i], src->pr_rhs[i]);
+
+      if (!stat.success)
+        return (struct gkyl_update_status) {
+          .success = false,
+          .dt_suggested = stat.dt_suggested
+        };
+
+      dt_suggested = fmin(dt_suggested, stat.dt_suggested);
     }
   }
 
   if (app->has_braginskii) {
     gkyl_moment_braginskii_advance(src->brag_slvr,
-      src->non_ideal_local_ext, app->local,
+      src->non_ideal_local, app->local,
       fluids, app->field.f[sidx[nstrang]],
       src->non_ideal_cflrate, src->non_ideal_vars, src->pr_rhs);
   }
@@ -267,6 +281,10 @@ moment_coupling_update(gkyl_moment_app *app, struct moment_coupling *src,
   if (app->has_field) {
     moment_field_apply_bc(app, tcurr, &app->field, app->field.f[sidx[nstrang]]);
   }
+  return (struct gkyl_update_status) {
+    .success = true,
+    .dt_suggested = dt_suggested
+  };
 }
 
 // free sources

--- a/moments/apps/mom_coupling.c
+++ b/moments/apps/mom_coupling.c
@@ -125,8 +125,8 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
 
   for (int n=0; n<app->num_species; ++n) {
     int meqn = app->species[n].num_equations;
-    src->pr_rhs[n] = mkarr(false, meqn, app->local_ext.volume);
-    src->non_ideal_cflrate[n] = mkarr(false, 1, app->local_ext.volume);
+    src->pr_rhs[n] = mkarr(app->use_gpu, meqn, app->local_ext.volume);
+    src->non_ideal_cflrate[n] = mkarr(app->use_gpu, 1, app->local_ext.volume);
   }
 
   int ghost[3] = { 1, 1, 1 };
@@ -139,7 +139,7 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
   for (int i=0; i<app->num_species; ++i) {
     if (app->species[i].eqn_type == GKYL_EQN_TEN_MOMENT && app->species[i].has_grad_closure) {
       int nadj[3] = { 1, 4, 8 }; // cells adjacent to a vertex
-      src->non_ideal_vars[i] = mkarr(false, nadj[app->ndim - 1]*10, src->non_ideal_local_ext.volume);
+      src->non_ideal_vars[i] = mkarr(app->use_gpu, nadj[app->ndim - 1]*10, src->non_ideal_local_ext.volume);
       struct gkyl_ten_moment_grad_closure_inp grad_closure_inp = {
         .grid = &app->grid,
         .k0 = app->species[i].k0,
@@ -160,7 +160,7 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
       .coll_fac = app->coll_fac == 0 ? 1.0 : app->coll_fac,
     };
     for (int i=0; i<app->num_species; ++i) {
-      src->non_ideal_vars[i] = mkarr(false, 10, src->non_ideal_local_ext.volume);
+      src->non_ideal_vars[i] = mkarr(app->use_gpu, 10, src->non_ideal_local_ext.volume);
       // Braginskii coefficients depend on pressure and coefficient to obtain
       // pressure is different for different equation systems (gasGamma, vt, Tr(P))
       double p_fac = 1.0;

--- a/moments/apps/mom_coupling.c
+++ b/moments/apps/mom_coupling.c
@@ -145,6 +145,8 @@ moment_coupling_init(const struct gkyl_moment_app *app, struct moment_coupling *
         .k0 = app->species[i].k0,
         .cfl = app->cfl,
         .comm = app->comm,
+        .update_range = &app->local,
+        .heat_flux_range = &src->non_ideal_local,
         .use_gpu = app->use_gpu,
       };
       src->grad_closure_slvr[i] = gkyl_ten_moment_grad_closure_new(grad_closure_inp);

--- a/moments/apps/mom_field.c
+++ b/moments/apps/mom_field.c
@@ -47,9 +47,9 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
       );
 
     // allocate arrays
-    fld->fdup = mkarr(false, 8, app->local_ext.volume);
+    fld->fdup = mkarr(app->use_gpu, 8, app->local_ext.volume);
     for (int d=0; d<ndim+1; ++d)
-      fld->f[d] = mkarr(false, 8, app->local_ext.volume);
+      fld->f[d] = mkarr(app->use_gpu, 8, app->local_ext.volume);
 
     // set current solution so ICs and IO work properly
     fld->fcurr = fld->f[0];
@@ -83,10 +83,10 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
     );
 
     // allocate arrays
-    fld->f0 = mkarr(false, 8, app->local_ext.volume);
-    fld->f1 = mkarr(false, 8, app->local_ext.volume);
-    fld->fnew = mkarr(false, 8, app->local_ext.volume);
-    fld->cflrate = mkarr(false, 1, app->local_ext.volume);
+    fld->f0 = mkarr(app->use_gpu, 8, app->local_ext.volume);
+    fld->f1 = mkarr(app->use_gpu, 8, app->local_ext.volume);
+    fld->fnew = mkarr(app->use_gpu, 8, app->local_ext.volume);
+    fld->cflrate = mkarr(app->use_gpu, 1, app->local_ext.volume);
 
     // set current solution so ICs and IO work properly
     fld->fcurr = fld->f0;
@@ -197,7 +197,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
 
   fld->use_explicit_em_coupling = mom_fld->use_explicit_em_coupling;
 
-  fld->ext_em = mkarr(false, 6, app->local_ext.volume);
+  fld->ext_em = mkarr(app->use_gpu, 6, app->local_ext.volume);
   gkyl_array_clear(fld->ext_em, 0.0);
   fld->has_ext_em = false;
   fld->ext_em_evolve = false;
@@ -216,12 +216,12 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
       mom_fld->ext_em, mom_fld->ext_em_ctx);    
   }  
 
-  fld->app_current = mkarr(false, 3, app->local_ext.volume);
+  fld->app_current = mkarr(app->use_gpu, 3, app->local_ext.volume);
   gkyl_array_clear(fld->app_current, 0.0);
   if(mom_fld->use_explicit_em_coupling){
-    fld->app_current1 = mkarr(false, 3, app->local_ext.volume);
+    fld->app_current1 = mkarr(app->use_gpu, 3, app->local_ext.volume);
     gkyl_array_clear(fld->app_current1, 0.0);
-    fld->app_current2 = mkarr(false, 3, app->local_ext.volume);
+    fld->app_current2 = mkarr(app->use_gpu, 3, app->local_ext.volume);
     gkyl_array_clear(fld->app_current2, 0.0);
   }
   fld->has_app_current = false;
@@ -251,7 +251,7 @@ moment_field_init(const struct gkyl_moment *mom, const struct gkyl_moment_field 
     long vol = app->skin_ghost.lower_skin[d].volume;
     buff_sz = buff_sz > vol ? buff_sz : vol;
   }
-  fld->bc_buffer = mkarr(false, 8, buff_sz);
+  fld->bc_buffer = mkarr(app->use_gpu, 8, buff_sz);
 
   gkyl_wv_eqn_release(maxwell);
 

--- a/moments/apps/mom_species.c
+++ b/moments/apps/mom_species.c
@@ -117,10 +117,10 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
         }
       );
       
-    sp->fdup = mkarr(false, meqn, app->local_ext.volume);
+    sp->fdup = mkarr(app->use_gpu, meqn, app->local_ext.volume);
     // allocate arrays
     for (int d=0; d<ndim+1; ++d)
-      sp->f[d] = mkarr(false, meqn, app->local_ext.volume);
+      sp->f[d] = mkarr(app->use_gpu, meqn, app->local_ext.volume);
   
     // set current solution so ICs and IO work properly
     sp->fcurr = sp->f[0];
@@ -161,11 +161,11 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
       );
     
     // allocate arrays
-    sp->f0 = mkarr(false, meqn, app->local_ext.volume);
-    sp->f1 = mkarr(false, meqn, app->local_ext.volume);
-    sp->fnew = mkarr(false, meqn, app->local_ext.volume);
-    sp->cflrate = mkarr(false, 1, app->local_ext.volume);
-    sp->alpha = mkarr(false, 1, app->local_ext.volume);
+    sp->f0 = mkarr(app->use_gpu, meqn, app->local_ext.volume);
+    sp->f1 = mkarr(app->use_gpu, meqn, app->local_ext.volume);
+    sp->fnew = mkarr(app->use_gpu, meqn, app->local_ext.volume);
+    sp->cflrate = mkarr(app->use_gpu, 1, app->local_ext.volume);
+    sp->alpha = mkarr(app->use_gpu, 1, app->local_ext.volume);
     
     // set current solution so ICs and IO work properly
     sp->fcurr = sp->f0;
@@ -290,7 +290,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
   }
 
   // allocate array for applied acceleration/forces for each species
-  sp->app_accel = mkarr(false, 3, app->local_ext.volume);
+  sp->app_accel = mkarr(app->use_gpu, 3, app->local_ext.volume);
   gkyl_array_clear(sp->app_accel, 0.0);
   sp->has_app_accel = false;
   sp->app_accel_evolve = false;
@@ -304,7 +304,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
       mom_sp->app_accel, mom_sp->app_accel_ctx);  
   }
 
-  sp->nT_source = mkarr(false, 2, app->local_ext.volume);
+  sp->nT_source = mkarr(app->use_gpu, 2, app->local_ext.volume);
   sp->nT_source_is_set = false;
   sp->proj_nT_source = 0;
   if (mom_sp->nT_source_func) {
@@ -325,7 +325,7 @@ moment_species_init(const struct gkyl_moment *mom, const struct gkyl_moment_spec
     long vol = app->skin_ghost.lower_skin[d].volume;
     buff_sz = buff_sz > vol ? buff_sz : vol;
   }
-  sp->bc_buffer = mkarr(false, meqn, buff_sz);
+  sp->bc_buffer = mkarr(app->use_gpu, meqn, buff_sz);
 
   if (mom_sp->equation->type == GKYL_EQN_EULER)
     sp->integ_q = gkyl_dynvec_new(GKYL_DOUBLE, 6); // KE and PE are stored independently

--- a/moments/apps/mom_species.c
+++ b/moments/apps/mom_species.c
@@ -407,20 +407,22 @@ moment_species_update(gkyl_moment_app *app,
   double max_speed = 0.0;
   struct gkyl_wave_prop_status stat;
 
-  for (int d=0; d<ndim; ++d) {
-    stat = gkyl_wave_prop_advance(sp->slvr[d], tcurr, dt, &app->local, sp->f[d], sp->f[d+1]);
+  if (!sp->is_static) {
+    for (int d=0; d<ndim; ++d) {
+      stat = gkyl_wave_prop_advance(sp->slvr[d], tcurr, dt, &app->local, sp->f[d], sp->f[d+1]);
 
-    double my_max_speed = stat.max_speed;
-    max_speed = max_speed > my_max_speed ? max_speed : my_max_speed;
+      double my_max_speed = stat.max_speed;
+      max_speed = max_speed > my_max_speed ? max_speed : my_max_speed;
 
-    if (!stat.success)
-      return (struct gkyl_update_status) {
-        .success = false,
-        .dt_suggested = stat.dt_suggested
-      };
+      if (!stat.success)
+        return (struct gkyl_update_status) {
+          .success = false,
+          .dt_suggested = stat.dt_suggested
+        };
     
-    dt_suggested = fmin(dt_suggested, stat.dt_suggested);
-    moment_species_apply_bc(app, tcurr, sp, sp->f[d+1]);
+      dt_suggested = fmin(dt_suggested, stat.dt_suggested);
+      moment_species_apply_bc(app, tcurr, sp, sp->f[d+1]);
+    }
   }
 
   for (int d=0; d<ndim; ++d) {

--- a/moments/apps/mom_species.c
+++ b/moments/apps/mom_species.c
@@ -408,8 +408,8 @@ moment_species_update(gkyl_moment_app *app,
   double max_speed = 0.0;
   struct gkyl_wave_prop_status stat;
 
-  if (!sp->is_static) {
-    for (int d=0; d<ndim; ++d) {
+  for (int d=0; d<ndim; ++d) {
+    if (!sp->is_static) {
       stat = gkyl_wave_prop_advance(sp->slvr[d], tcurr, dt, &app->local, sp->f[d], sp->f[d+1]);
 
       double my_max_speed = stat.max_speed;
@@ -422,8 +422,11 @@ moment_species_update(gkyl_moment_app *app,
         };
     
       dt_suggested = fmin(dt_suggested, stat.dt_suggested);
-      moment_species_apply_bc(app, tcurr, sp, sp->f[d+1]);
     }
+    else {
+      gkyl_array_copy(sp->f[d+1], sp->f[d]);
+    }
+    moment_species_apply_bc(app, tcurr, sp, sp->f[d+1]);
   }
 
   for (int d=0; d<ndim; ++d) {

--- a/moments/apps/mom_update_one_step.c
+++ b/moments/apps/mom_update_one_step.c
@@ -41,7 +41,15 @@ moment_update_one_step(gkyl_moment_app* app, double dt0)
 
         if (app->update_sources) {
           struct timespec src1_tm = gkyl_wall_clock();
-          moment_coupling_update(app, &app->sources, 0, tcurr, dt/2);
+          struct gkyl_update_status s = moment_coupling_update(app, &app->sources,
+            0, tcurr, dt/2);
+          if (!s.success) {
+            app->stat.nfail += 1;
+            dt = s.dt_suggested;
+            state = UPDATE_REDO;
+            break;
+          }
+          dt_suggested = fmin(dt_suggested, s.dt_suggested);
           app->stat.sources_tm += gkyl_time_diff_now_sec(src1_tm);
         }
         if (app->update_mhd_source) {

--- a/moments/apps/moment.c
+++ b/moments/apps/moment.c
@@ -124,7 +124,7 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
     gkyl_create_ranges(&app->decomp->ranges[rank], ghost, &app->local_ext, &app->local);
   }
 
-  skin_ghost_ranges_init(&app->skin_ghost, &app->global_ext, ghost);  
+  skin_ghost_ranges_init(&app->skin_ghost, &app->local_ext, ghost);  
   
   app->c2p_ctx = app->mapc2p = 0;  
   app->has_mapc2p = mom->mapc2p ? true : false;

--- a/moments/apps/moment.c
+++ b/moments/apps/moment.c
@@ -145,7 +145,7 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
     gkyl_cart_modal_tensor(&basis, ndim, 1);
 
     // initialize DG field representing mapping
-    struct gkyl_array *c2p = mkarr(false, ndim*basis.num_basis, app->local_ext.volume);
+    struct gkyl_array *c2p = mkarr(app->use_gpu, ndim*basis.num_basis, app->local_ext.volume);
     gkyl_eval_on_nodes *ev_c2p = gkyl_eval_on_nodes_new(&app->grid, &basis, ndim, mom->mapc2p, mom->c2p_ctx);
     gkyl_eval_on_nodes_advance(ev_c2p, 0.0, &app->local_ext, c2p);
 
@@ -238,11 +238,11 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
       max_eqn = int_max(max_eqn, app->species[i].num_equations);
     if (app->has_field)
       max_eqn = int_max(max_eqn, 8); // maxwell equations have 8 components
-    app->ql = mkarr(false, max_eqn, app->local_ext.volume);
-    app->qr = mkarr(false, max_eqn, app->local_ext.volume);
+    app->ql = mkarr(app->use_gpu, max_eqn, app->local_ext.volume);
+    app->qr = mkarr(app->use_gpu, max_eqn, app->local_ext.volume);
 
-    app->amdq = mkarr(false, max_eqn, app->local_ext.volume);
-    app->apdq = mkarr(false, max_eqn, app->local_ext.volume);
+    app->amdq = mkarr(app->use_gpu, max_eqn, app->local_ext.volume);
+    app->apdq = mkarr(app->use_gpu, max_eqn, app->local_ext.volume);
   }
 
   // initialize stat object to all zeros

--- a/moments/apps/moment.c
+++ b/moments/apps/moment.c
@@ -145,7 +145,7 @@ gkyl_moment_app_new(struct gkyl_moment *mom)
     gkyl_cart_modal_tensor(&basis, ndim, 1);
 
     // initialize DG field representing mapping
-    struct gkyl_array *c2p = mkarr(app->use_gpu, ndim*basis.num_basis, app->local_ext.volume);
+    struct gkyl_array *c2p = mkarr(false, ndim*basis.num_basis, app->local_ext.volume);
     gkyl_eval_on_nodes *ev_c2p = gkyl_eval_on_nodes_new(&app->grid, &basis, ndim, mom->mapc2p, mom->c2p_ctx);
     gkyl_eval_on_nodes_advance(ev_c2p, 0.0, &app->local_ext, c2p);
 

--- a/moments/zero/gkyl_moment_non_ideal_priv.h
+++ b/moments/zero/gkyl_moment_non_ideal_priv.h
@@ -44,6 +44,7 @@ static const unsigned QZ = 8;
 
 // Calculate symmetrized gradient 1D
 // Based on Günter, Lackner, & Tichmann 2005 JCP
+GKYL_CU_D
 static inline double
 calc_sym_grad_1D(double dx, double a_l, double a_u)
 {
@@ -51,12 +52,14 @@ calc_sym_grad_1D(double dx, double a_l, double a_u)
 }
 
 // Calculate symmetrized gradients 2D
+GKYL_CU_D
 static inline double
 calc_sym_gradx_2D(double dx, double a_ll, double a_lu, double a_ul, double a_uu)
 {
   return (a_ul + a_uu - a_ll - a_lu)/(2*dx);
 }
 
+GKYL_CU_D
 static inline double
 calc_sym_grady_2D(double dy, double a_ll, double a_lu, double a_ul, double a_uu)
 {
@@ -64,18 +67,21 @@ calc_sym_grady_2D(double dy, double a_ll, double a_lu, double a_ul, double a_uu)
 }
 
 // Calculate symmetrized gradients 3D
+GKYL_CU_D
 static inline double
 calc_sym_gradx_3D(double dx, double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
 {
   return (a_ull + a_ulu + a_uul + a_uuu - a_lll - a_llu - a_lul - a_luu)/(4*dx);
 }
 
+GKYL_CU_D
 static inline double
 calc_sym_grady_3D(double dy, double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
 {
   return (a_lul + a_luu + a_uul + a_uuu - a_lll - a_llu - a_ull - a_ulu)/(4*dy);
 }
 
+GKYL_CU_D
 static inline double
 calc_sym_gradz_3D(double dz, double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
 {
@@ -83,12 +89,14 @@ calc_sym_gradz_3D(double dz, double a_lll, double a_llu, double a_lul, double a_
 }
 
 // In 1D, computes quantity at cell edge of two-cell interface
+GKYL_CU_D
 static inline double
 calc_arithm_avg_1D(double a_l, double a_u)
 {
   return 0.5*(a_l + a_u);
 }
 
+GKYL_CU_D
 static inline double
 calc_harmonic_avg_1D(double a_l, double a_u)
 {
@@ -96,12 +104,14 @@ calc_harmonic_avg_1D(double a_l, double a_u)
 }
 
 // In 2D, computes quantity at cell corner of four-cell interface
+GKYL_CU_D
 static inline double
 calc_arithm_avg_2D(double a_ll, double a_lu, double a_ul, double a_uu)
 {
   return 0.25*(a_ll + a_lu + a_ul + a_uu);
 }
 
+GKYL_CU_D
 static inline double
 calc_harmonic_avg_2D(double a_ll, double a_lu, double a_ul, double a_uu)
 {
@@ -109,12 +119,14 @@ calc_harmonic_avg_2D(double a_ll, double a_lu, double a_ul, double a_uu)
 }
 
 // In 3D, computes quantity at cell corner of eight-cell interface
+GKYL_CU_D
 static inline double
 calc_arithm_avg_3D(double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
 {
   return 0.125*(a_lll + a_llu + a_lul + a_luu + a_ull + a_ulu + a_uul + a_uuu);
 }
 
+GKYL_CU_D
 static inline double
 calc_harmonic_avg_3D(double a_lll, double a_llu, double a_lul, double a_luu, double a_ull, double a_ulu, double a_uul, double a_uuu)
 {
@@ -123,6 +135,7 @@ calc_harmonic_avg_3D(double a_lll, double a_llu, double a_lul, double a_luu, dou
 
 // Calculate grad(u)
 // In 1D, computes tensor at cell edge of two-cell interface
+GKYL_CU_D
 static inline void
 calc_grad_u_1D(double dx, double u_l[3], double u_u[3], double grad_u[3])
 {
@@ -132,6 +145,7 @@ calc_grad_u_1D(double dx, double u_l[3], double u_u[3], double grad_u[3])
 }
 
 // In 2D, computes tensor computes tensor in one corner of four-cell interface
+GKYL_CU_D
 static inline void
 calc_grad_u_2D(double dx, double dy, double u_ll[3], double u_lu[3], double u_ul[3], double u_uu[3], double grad_u[6])
 {
@@ -145,6 +159,7 @@ calc_grad_u_2D(double dx, double dy, double u_ll[3], double u_lu[3], double u_ul
 }
 
 // In 3D, computes tensor in one corner of eight-cell interface
+GKYL_CU_D
 static inline void
 calc_grad_u_3D(double dx, double dy, double dz, double u_lll[3], double u_llu[3], double u_lul[3], double u_luu[3], double u_ull[3], double u_ulu[3], double u_uul[3], double u_uuu[3], double grad_u[9])
 {
@@ -163,6 +178,7 @@ calc_grad_u_3D(double dx, double dy, double dz, double u_lll[3], double u_llu[3]
 
 // Calculate rate of strain tensor
 // In 1D, computes tensor at cell edge of two-cell interface
+GKYL_CU_D
 static inline void
 calc_ros_1D(double dx, double u_l[3], double u_u[3], double w[6])
 {
@@ -178,6 +194,7 @@ calc_ros_1D(double dx, double u_l[3], double u_u[3], double w[6])
 }
 
 // In 2D, computes tensor in one corner of four-cell interface
+GKYL_CU_D
 static inline void
 calc_ros_2D(double dx, double dy, double u_ll[3], double u_lu[3], double u_ul[3], double u_uu[3], double w[6])
 {
@@ -194,6 +211,7 @@ calc_ros_2D(double dx, double dy, double u_ll[3], double u_lu[3], double u_ul[3]
 }
 
 // In 3D, computes tensor in one corner of eight-cell interface
+GKYL_CU_D
 static inline void
 calc_ros_3D(double dx, double dy, double dz, double u_lll[3], double u_llu[3], double u_lul[3], double u_luu[3], double u_ull[3], double u_ulu[3], double u_uul[3], double u_uuu[3], double w[6])
 {
@@ -211,6 +229,7 @@ calc_ros_3D(double dx, double dy, double dz, double u_lll[3], double u_llu[3], d
 
 // Magnetized closure helper functions
 // Calculate the magnitude of the local magnetic field
+GKYL_CU_D
 static inline double
 calc_mag_b(const double em_tot[8])
 {
@@ -218,6 +237,7 @@ calc_mag_b(const double em_tot[8])
 }
 
 // Calculate the cyclotron frequency based on the species' parameters
+GKYL_CU_D
 static inline double
 calc_omega_c(double charge, double mass, const double em_tot[8])
 {
@@ -229,6 +249,7 @@ calc_omega_c(double charge, double mass, const double em_tot[8])
 }
 
 // Calculate magnetic field unit vector
+GKYL_CU_D
 static inline void
 calc_bhat(const double em_tot[8], double b[3])
 {
@@ -247,6 +268,7 @@ calc_bhat(const double em_tot[8], double b[3])
 // Calculate the collision time based on the species' parameters
 // Note: assumes the electron-ion collision frequency so sqrt(2) may be missing
 //       coulomb_log considered constant, rho is mass density, temp is temperature
+GKYL_CU_D
 static inline double
 calc_tau(double coulomb_log, double coll_fac, double epsilon0, double charge1, double charge2, double mass1, double mass2, double rho, double temp)
 {
@@ -254,6 +276,7 @@ calc_tau(double coulomb_log, double coll_fac, double epsilon0, double charge1, d
 }
 
 // Calculate magnetized parallel viscous stress tensor
+GKYL_CU_D
 static void
 calc_pi_par(double eta_par, double b_avg[3], double w[6], double pi_par[6])
 { 
@@ -272,6 +295,7 @@ calc_pi_par(double eta_par, double b_avg[3], double w[6], double pi_par[6])
 }
 
 // Calculate magnetized perpendicular viscous stress tensor
+GKYL_CU_D
 static void
 calc_pi_perp(double eta_perp, double b_avg[3], double w[6], double pi_perp[6])
 {   
@@ -297,6 +321,7 @@ calc_pi_perp(double eta_perp, double b_avg[3], double w[6], double pi_perp[6])
 }
 
 // Calculate magnetized gyroviscous viscous stress tensor
+GKYL_CU_D
 static void
 calc_pi_cross(double eta_cross, double b_avg[3], double w[6], double pi_cross[6])
 {

--- a/moments/zero/gkyl_ten_moment_grad_closure.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure.h
@@ -11,6 +11,14 @@
 struct gkyl_ten_moment_grad_closure_inp {
     const struct gkyl_rect_grid *grid; // grid on which to solve equations
     double k0; // inversedamping coefficient
+    double cfl; // CFL number to use
+
+    struct gkyl_comm *comm;
+};
+
+struct gkyl_ten_moment_grad_closure_status {
+  int success; // 1 if step worked, 0 otherwise
+  double dt_suggested; // suggested time-step
 };
 
 // Object type
@@ -42,10 +50,11 @@ gkyl_ten_moment_grad_closure* gkyl_ten_moment_grad_closure_new(struct gkyl_ten_m
  * @param rhs RHS output (NOTE: Returns RHS output of all nfluids)
  */
 
-void gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces, 
-  const struct gkyl_range *heat_flux_range, const struct gkyl_range *update_range,
-  const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
-  struct gkyl_array *cflrate, struct gkyl_array *heat_flux, struct gkyl_array *rhs);
+struct gkyl_ten_moment_grad_closure_status gkyl_ten_moment_grad_closure_advance(
+  const gkyl_ten_moment_grad_closure *gces, const struct gkyl_range *heat_flux_range,
+  const struct gkyl_range *update_range, const struct gkyl_array *fluid,
+  const struct gkyl_array *em_tot, struct gkyl_array *cflrate, double dt,
+  struct gkyl_array *heat_flux, struct gkyl_array *rhs);
 
 /**
  * Delete updater.

--- a/moments/zero/gkyl_ten_moment_grad_closure.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure.h
@@ -9,11 +9,12 @@
 #include <gkyl_util.h>
 
 struct gkyl_ten_moment_grad_closure_inp {
-    const struct gkyl_rect_grid *grid; // grid on which to solve equations
-    double k0; // inversedamping coefficient
-    double cfl; // CFL number to use
+  const struct gkyl_rect_grid *grid; // grid on which to solve equations
+  double k0; // inversedamping coefficient
+  double cfl; // CFL number to use
+  bool use_gpu; // Boolean to determine whether wave equation object is on host or device
 
-    struct gkyl_comm *comm;
+  struct gkyl_comm *comm;
 };
 
 struct gkyl_ten_moment_grad_closure_status {

--- a/moments/zero/gkyl_ten_moment_grad_closure.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure.h
@@ -12,6 +12,8 @@ struct gkyl_ten_moment_grad_closure_inp {
   const struct gkyl_rect_grid *grid; // grid on which to solve equations
   double k0; // inversedamping coefficient
   double cfl; // CFL number to use
+  const struct gkyl_range *update_range;
+  struct gkyl_range *heat_flux_range;
   bool use_gpu; // Boolean to determine whether wave equation object is on host or device
 
   struct gkyl_comm *comm;

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -1,8 +1,7 @@
 #include <gkyl_moment_non_ideal_priv.h>
 
-typedef double (*heat_flux_calc_t)(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double cfl,
-  double dt, double *rhs_d[]);
+typedef void (*heat_flux_calc_t)(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[]);
 
 struct gkyl_ten_moment_grad_closure {
   struct gkyl_rect_grid grid; // grid object
@@ -102,10 +101,9 @@ calc_sym_grad_limiter_3D(double alpha, double a, double b, double c, double d)
   }
 }
 
-double
+void
 calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate,
-  double cfl, double dt, double *rhs_d[])
+  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[])
 {
   const int ndim = gces->ndim;
   double rho_avg = 0.0;
@@ -161,13 +159,12 @@ calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
   rhs_d[U_1D][P33] += signx[U_1D]*q[Q133]/dx;
 
   double cfla = dt/(dx*dx);
-  return fmax(alpha*vth_avg*cfla, cfl);
+  cflrate[0] = alpha*vth_avg*cfla;
 }
 
-double
+void
 calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate,
-  double cfl, double dt, double *rhs_d[])
+  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[])
 {
   const int ndim = gces->ndim;
   double rho_avg = 0.0;
@@ -353,13 +350,12 @@ calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
   
   double da = fmin(dx, dy);
   double cfla = dt/(da*da);
-  return fmax(alpha*vth_avg*cfla, cfl);
+  cflrate[0] = alpha*vth_avg*cfla;
 }
 
-double
+void
 calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate,
-  double cfl, double dt, double *rhs_d[])
+  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[])
 {
   const int ndim = gces->ndim;
   double rho_avg = 0.0;
@@ -941,7 +937,7 @@ calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
 
   double da = fmin(fmin(dx, dy), dz);
   double cfla = dt/(da*da);
-  return fmax(alpha*vth_avg*cfla, cfl);
+  cflrate[0] = alpha*vth_avg*cfla;
 }
 
 static const heat_flux_calc_t grad_closure_unmag_funcs[3] = { calc_unmag_heat_flux_1d,

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -1,7 +1,10 @@
 #include <gkyl_moment_non_ideal_priv.h>
 
 typedef void (*heat_flux_calc_t)(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[]);
+  const double *fluid_d[], double *cflrate, double dt, double *q);
+
+typedef void (*heat_flux_update_t)(const gkyl_ten_moment_grad_closure *gces,
+  const double *q[], double *rhs);
 
 struct gkyl_ten_moment_grad_closure {
   struct gkyl_rect_grid grid; // grid object
@@ -13,6 +16,7 @@ struct gkyl_ten_moment_grad_closure {
   struct gkyl_comm *comm;
 
   heat_flux_calc_t calc_q;
+  heat_flux_update_t update_q;
 };
 
 // Makes indexing cleaner
@@ -105,7 +109,7 @@ calc_sym_grad_limiter_3D(double alpha, double a, double b, double c, double d)
 
 void
 calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[])
+  const double *fluid_d[], double *cflrate, double dt, double *q)
 {
   const int ndim = gces->ndim;
   double rho_avg = 0.0;
@@ -118,7 +122,6 @@ calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
   double Tij[2][6] = {0.0};
   double rho[2] = {0.0};
   double p[2] = {0.0};
-  double q[10] = {0.0};
   var_setup(gces, L_1D, U_1D, fluid_d, rho, p, Tij);
 
   rho_avg = calc_harmonic_avg_1D(rho[L_1D], rho[U_1D]);
@@ -145,28 +148,40 @@ calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
   q[Q123] = chi*dTdx[T23]/3.0;
   q[Q133] = chi*dTdx[T33]/3.0;
 
-  int signx[2] = { 1.0, -1.0 };
-  rhs_d[L_1D][P11] += signx[L_1D]*q[Q111]/dx;
-  rhs_d[L_1D][P12] += signx[L_1D]*q[Q112]/dx;
-  rhs_d[L_1D][P13] += signx[L_1D]*q[Q113]/dx;
-  rhs_d[L_1D][P22] += signx[L_1D]*q[Q122]/dx;
-  rhs_d[L_1D][P23] += signx[L_1D]*q[Q123]/dx;
-  rhs_d[L_1D][P33] += signx[L_1D]*q[Q133]/dx;
-
-  rhs_d[U_1D][P11] += signx[U_1D]*q[Q111]/dx;
-  rhs_d[U_1D][P12] += signx[U_1D]*q[Q112]/dx;
-  rhs_d[U_1D][P13] += signx[U_1D]*q[Q113]/dx;
-  rhs_d[U_1D][P22] += signx[U_1D]*q[Q122]/dx;
-  rhs_d[U_1D][P23] += signx[U_1D]*q[Q123]/dx;
-  rhs_d[U_1D][P33] += signx[U_1D]*q[Q133]/dx;
-
   double cfla = dt/(dx*dx);
   cflrate[0] = alpha*vth_avg*cfla;
 }
 
 void
+grad_closure_update_1d(const gkyl_ten_moment_grad_closure *gces,
+  const double *q[], double *rhs)
+{
+  double div_qx[6] = {0.0};
+
+  const double dx = gces->grid.dx[0];
+
+  div_qx[0] = calc_sym_grad_1D(dx, q[L_1D][Q111], q[U_1D][Q111]);
+  div_qx[1] = calc_sym_grad_1D(dx, q[L_1D][Q112], q[U_1D][Q112]);
+  div_qx[2] = calc_sym_grad_1D(dx, q[L_1D][Q113], q[U_1D][Q113]);
+  div_qx[3] = calc_sym_grad_1D(dx, q[L_1D][Q122], q[U_1D][Q122]);
+  div_qx[4] = calc_sym_grad_1D(dx, q[L_1D][Q123], q[U_1D][Q123]);
+  div_qx[5] = calc_sym_grad_1D(dx, q[L_1D][Q133], q[U_1D][Q133]);
+
+  rhs[RHO] = 0.0;
+  rhs[MX] = 0.0;
+  rhs[MY] = 0.0;
+  rhs[MZ] = 0.0;
+  rhs[P11] = div_qx[0];
+  rhs[P12] = div_qx[1];
+  rhs[P13] = div_qx[2];
+  rhs[P22] = div_qx[3];
+  rhs[P23] = div_qx[4];
+  rhs[P33] = div_qx[5];
+}
+
+void
 calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[])
+  const double *fluid_d[], double *cflrate, double dt, double *q)
 {
   const int ndim = gces->ndim;
   double rho_avg = 0.0;
@@ -182,7 +197,6 @@ calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
   double Tij[4][6] = {0.0};
   double rho[4] = {0.0};
   double p[4] = {0.0};
-  double q[4][10] = {0.0};
   var_setup(gces, LL_2D, UU_2D, fluid_d, rho, p, Tij);
 
   rho_avg = calc_harmonic_avg_2D(rho[LL_2D], rho[LU_2D], rho[UL_2D], rho[UU_2D]);
@@ -244,7 +258,6 @@ calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
   dTdy[U_1D][T23] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T23], dTy[L_1D][T23]);
   dTdy[U_1D][T33] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T33], dTy[L_1D][T33]);
 
-
   double alpha = 1.0/gces->k0;
   double vth_avg = sqrt(p_avg/rho_avg);
 
@@ -255,109 +268,114 @@ calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
   int compx[4] = { L_1D, U_1D, L_1D, U_1D };
   int compy[4] = { L_1D, L_1D, U_1D, U_1D };
 
-  int signx[4] = { 1.0, 1.0, -1.0, -1.0 };
-  int signy[4] = { 1.0, -1.0, 1.0, -1.0 };
+  q[LL_2D*10 + Q111] = chi*dTdx[compx[LL_2D]][T11];
+  q[LL_2D*10 + Q112] = chi*(2.0*dTdx[compx[LL_2D]][T12]
+    + dTdy[compy[LL_2D]][T11])/3.0;
+  q[LL_2D*10 + Q113] = chi*2.0*dTdx[compx[LL_2D]][T13]/3.0;
+  q[LL_2D*10 + Q122] = chi*(dTdx[compx[LL_2D]][T22]
+    + 2.0*dTdy[compy[LL_2D]][T12])/3.0;
+  q[LL_2D*10 + Q123] = chi*(dTdx[compx[LL_2D]][T23]
+    + dTdy[compy[LL_2D]][T13])/3.0;
+  q[LL_2D*10 + Q133] = chi*dTdx[compx[LL_2D]][T33]/3.0;
+  q[LL_2D*10 + Q222] = chi*dTdy[compy[LL_2D]][T22];
+  q[LL_2D*10 + Q223] = chi*2.0*dTdy[compy[LL_2D]][T23]/3.0;
+  q[LL_2D*10 + Q233] = chi*dTdy[compy[LL_2D]][T33]/3.0;
 
-  q[LL_2D][Q111] = chi*dTdx[compx[LL_2D]][T11];
-  q[LL_2D][Q112] = chi*(2.0*dTdx[compx[LL_2D]][T12] + dTdy[compy[LL_2D]][T11])/3.0;
-  q[LL_2D][Q113] = chi*2.0*dTdx[compx[LL_2D]][T13]/3.0;
-  q[LL_2D][Q122] = chi*(dTdx[compx[LL_2D]][T22] + 2.0*dTdy[compy[LL_2D]][T12])/3.0;
-  q[LL_2D][Q123] = chi*(dTdx[compx[LL_2D]][T23] + dTdy[compy[LL_2D]][T13])/3.0;
-  q[LL_2D][Q133] = chi*dTdx[compx[LL_2D]][T33]/3.0;
-  q[LL_2D][Q222] = chi*dTdy[compy[LL_2D]][T22];
-  q[LL_2D][Q223] = chi*2.0*dTdy[compy[LL_2D]][T23]/3.0;
-  q[LL_2D][Q233] = chi*dTdy[compy[LL_2D]][T33]/3.0;
+  q[LU_2D*10 + Q111] = chi*dTdx[compx[LU_2D]][T11];
+  q[LU_2D*10 + Q112] = chi*(2.0*dTdx[compx[LU_2D]][T12]
+    + dTdy[compy[LU_2D]][T11])/3.0;
+  q[LU_2D*10 + Q113] = chi*2.0*dTdx[compx[LU_2D]][T13]/3.0;
+  q[LU_2D*10 + Q122] = chi*(dTdx[compx[LU_2D]][T22]
+    + 2.0*dTdy[compy[LU_2D]][T12])/3.0;
+  q[LU_2D*10 + Q123] = chi*(dTdx[compx[LU_2D]][T23]
+    + dTdy[compy[LU_2D]][T13])/3.0;
+  q[LU_2D*10 + Q133] = chi*dTdx[compx[LU_2D]][T33]/3.0;
+  q[LU_2D*10 + Q222] = chi*dTdy[compy[LU_2D]][T22];
+  q[LU_2D*10 + Q223] = chi*2.0*dTdy[compy[LU_2D]][T23]/3.0;
+  q[LU_2D*10 + Q233] = chi*dTdy[compy[LU_2D]][T33]/3.0;
 
-  q[LU_2D][Q111] = chi*dTdx[compx[LU_2D]][T11];
-  q[LU_2D][Q112] = chi*(2.0*dTdx[compx[LU_2D]][T12] + dTdy[compy[LU_2D]][T11])/3.0;
-  q[LU_2D][Q113] = chi*2.0*dTdx[compx[LU_2D]][T13]/3.0;
-  q[LU_2D][Q122] = chi*(dTdx[compx[LU_2D]][T22] + 2.0*dTdy[compy[LU_2D]][T12])/3.0;
-  q[LU_2D][Q123] = chi*(dTdx[compx[LU_2D]][T23] + dTdy[compy[LU_2D]][T13])/3.0;
-  q[LU_2D][Q133] = chi*dTdx[compx[LU_2D]][T33]/3.0;
-  q[LU_2D][Q222] = chi*dTdy[compy[LU_2D]][T22];
-  q[LU_2D][Q223] = chi*2.0*dTdy[compy[LU_2D]][T23]/3.0;
-  q[LU_2D][Q233] = chi*dTdy[compy[LU_2D]][T33]/3.0;
+  q[UL_2D*10 + Q111] = chi*dTdx[compx[UL_2D]][T11];
+  q[UL_2D*10 + Q112] = chi*(2.0*dTdx[compx[UL_2D]][T12]
+    + dTdy[compy[UL_2D]][T11])/3.0;
+  q[UL_2D*10 + Q113] = chi*2.0*dTdx[compx[UL_2D]][T13]/3.0;
+  q[UL_2D*10 + Q122] = chi*(dTdx[compx[UL_2D]][T22]
+    + 2.0*dTdy[compy[UL_2D]][T12])/3.0;
+  q[UL_2D*10 + Q123] = chi*(dTdx[compx[UL_2D]][T23]
+    + dTdy[compy[UL_2D]][T13])/3.0;
+  q[UL_2D*10 + Q133] = chi*dTdx[compx[UL_2D]][T33]/3.0;
+  q[UL_2D*10 + Q222] = chi*dTdy[compy[UL_2D]][T22];
+  q[UL_2D*10 + Q223] = chi*2.0*dTdy[compy[UL_2D]][T23]/3.0;
+  q[UL_2D*10 + Q233] = chi*dTdy[compy[UL_2D]][T33]/3.0;
 
-  q[UL_2D][Q111] = chi*dTdx[compx[UL_2D]][T11];
-  q[UL_2D][Q112] = chi*(2.0*dTdx[compx[UL_2D]][T12] + dTdy[compy[UL_2D]][T11])/3.0;
-  q[UL_2D][Q113] = chi*2.0*dTdx[compx[UL_2D]][T13]/3.0;
-  q[UL_2D][Q122] = chi*(dTdx[compx[UL_2D]][T22] + 2.0*dTdy[compy[UL_2D]][T12])/3.0;
-  q[UL_2D][Q123] = chi*(dTdx[compx[UL_2D]][T23] + dTdy[compy[UL_2D]][T13])/3.0;
-  q[UL_2D][Q133] = chi*dTdx[compx[UL_2D]][T33]/3.0;
-  q[UL_2D][Q222] = chi*dTdy[compy[UL_2D]][T22];
-  q[UL_2D][Q223] = chi*2.0*dTdy[compy[UL_2D]][T23]/3.0;
-  q[UL_2D][Q233] = chi*dTdy[compy[UL_2D]][T33]/3.0;
+  q[UU_2D*10 + Q111] = chi*dTdx[compx[UU_2D]][T11];
+  q[UU_2D*10 + Q112] = chi*(2.0*dTdx[compx[UU_2D]][T12]
+    + dTdy[compy[UU_2D]][T11])/3.0;
+  q[UU_2D*10 + Q113] = chi*2.0*dTdx[compx[UU_2D]][T13]/3.0;
+  q[UU_2D*10 + Q122] = chi*(dTdx[compx[UU_2D]][T22]
+    + 2.0*dTdy[compy[UU_2D]][T12])/3.0;
+  q[UU_2D*10 + Q123] = chi*(dTdx[compx[UU_2D]][T23]
+    + dTdy[compy[UU_2D]][T13])/3.0;
+  q[UU_2D*10 + Q133] = chi*dTdx[compx[UU_2D]][T33]/3.0;
+  q[UU_2D*10 + Q222] = chi*dTdy[compy[UU_2D]][T22];
+  q[UU_2D*10 + Q223] = chi*2.0*dTdy[compy[UU_2D]][T23]/3.0;
+  q[UU_2D*10 + Q233] = chi*dTdy[compy[UU_2D]][T33]/3.0;
 
-  q[UU_2D][Q111] = chi*dTdx[compx[UU_2D]][T11];
-  q[UU_2D][Q112] = chi*(2.0*dTdx[compx[UU_2D]][T12] + dTdy[compy[UU_2D]][T11])/3.0;
-  q[UU_2D][Q113] = chi*2.0*dTdx[compx[UU_2D]][T13]/3.0;
-  q[UU_2D][Q122] = chi*(dTdx[compx[UU_2D]][T22] + 2.0*dTdy[compy[UU_2D]][T12])/3.0;
-  q[UU_2D][Q123] = chi*(dTdx[compx[UU_2D]][T23] + dTdy[compy[UU_2D]][T13])/3.0;
-  q[UU_2D][Q133] = chi*dTdx[compx[UU_2D]][T33]/3.0;
-  q[UU_2D][Q222] = chi*dTdy[compy[UU_2D]][T22];
-  q[UU_2D][Q223] = chi*2.0*dTdy[compy[UU_2D]][T23]/3.0;
-  q[UU_2D][Q233] = chi*dTdy[compy[UU_2D]][T33]/3.0;
-
-  rhs_d[LL_2D][P11] += signx[LL_2D]*q[LL_2D][Q111]/(2.0*dx)
-    + signy[LL_2D]*q[LL_2D][Q112]/(2.0*dy);
-  rhs_d[LL_2D][P12] += signx[LL_2D]*q[LL_2D][Q112]/(2.0*dx)
-    + signy[LL_2D]*q[LL_2D][Q122]/(2.0*dy);
-  rhs_d[LL_2D][P13] += signx[LL_2D]*q[LL_2D][Q113]/(2.0*dx)
-    + signy[LL_2D]*q[LL_2D][Q123]/(2.0*dy);
-  rhs_d[LL_2D][P22] += signx[LL_2D]*q[LL_2D][Q122]/(2.0*dx)
-    + signy[LL_2D]*q[LL_2D][Q222]/(2.0*dy);
-  rhs_d[LL_2D][P23] += signx[LL_2D]*q[LL_2D][Q123]/(2.0*dx)
-    + signy[LL_2D]*q[LL_2D][Q223]/(2.0*dy);
-  rhs_d[LL_2D][P33] += signx[LL_2D]*q[LL_2D][Q133]/(2.0*dx)
-    + signy[LL_2D]*q[LL_2D][Q233]/(2.0*dy);
-
-  rhs_d[LU_2D][P11] += signx[LU_2D]*q[LU_2D][Q111]/(2.0*dx)
-    + signy[LU_2D]*q[LU_2D][Q112]/(2.0*dy);
-  rhs_d[LU_2D][P12] += signx[LU_2D]*q[LU_2D][Q112]/(2.0*dx)
-    + signy[LU_2D]*q[LU_2D][Q122]/(2.0*dy);
-  rhs_d[LU_2D][P13] += signx[LU_2D]*q[LU_2D][Q113]/(2.0*dx)
-    + signy[LU_2D]*q[LU_2D][Q123]/(2.0*dy);
-  rhs_d[LU_2D][P22] += signx[LU_2D]*q[LU_2D][Q122]/(2.0*dx)
-    + signy[LU_2D]*q[LU_2D][Q222]/(2.0*dy);
-  rhs_d[LU_2D][P23] += signx[LU_2D]*q[LU_2D][Q123]/(2.0*dx)
-    + signy[LU_2D]*q[LU_2D][Q223]/(2.0*dy);
-  rhs_d[LU_2D][P33] += signx[LU_2D]*q[LU_2D][Q133]/(2.0*dx)
-    + signy[LU_2D]*q[LU_2D][Q233]/(2.0*dy);
-
-  rhs_d[UL_2D][P11] += signx[UL_2D]*q[UL_2D][Q111]/(2.0*dx)
-    + signy[UL_2D]*q[UL_2D][Q112]/(2.0*dy);
-  rhs_d[UL_2D][P12] += signx[UL_2D]*q[UL_2D][Q112]/(2.0*dx)
-    + signy[UL_2D]*q[UL_2D][Q122]/(2.0*dy);
-  rhs_d[UL_2D][P13] += signx[UL_2D]*q[UL_2D][Q113]/(2.0*dx)
-    + signy[UL_2D]*q[UL_2D][Q123]/(2.0*dy);
-  rhs_d[UL_2D][P22] += signx[UL_2D]*q[UL_2D][Q122]/(2.0*dx)
-    + signy[UL_2D]*q[UL_2D][Q222]/(2.0*dy);
-  rhs_d[UL_2D][P23] += signx[UL_2D]*q[UL_2D][Q123]/(2.0*dx)
-    + signy[UL_2D]*q[UL_2D][Q223]/(2.0*dy);
-  rhs_d[UL_2D][P33] += signx[UL_2D]*q[UL_2D][Q133]/(2.0*dx)
-    + signy[UL_2D]*q[UL_2D][Q233]/(2.0*dy);
-
-  rhs_d[UU_2D][P11] += signx[UU_2D]*q[UU_2D][Q111]/(2.0*dx)
-    + signy[UU_2D]*q[UU_2D][Q112]/(2.0*dy);
-  rhs_d[UU_2D][P12] += signx[UU_2D]*q[UU_2D][Q112]/(2.0*dx)
-    + signy[UU_2D]*q[UU_2D][Q122]/(2.0*dy);
-  rhs_d[UU_2D][P13] += signx[UU_2D]*q[UU_2D][Q113]/(2.0*dx)
-    + signy[UU_2D]*q[UU_2D][Q123]/(2.0*dy);
-  rhs_d[UU_2D][P22] += signx[UU_2D]*q[UU_2D][Q122]/(2.0*dx)
-    + signy[UU_2D]*q[UU_2D][Q222]/(2.0*dy);
-  rhs_d[UU_2D][P23] += signx[UU_2D]*q[UU_2D][Q123]/(2.0*dx)
-    + signy[UU_2D]*q[UU_2D][Q223]/(2.0*dy);
-  rhs_d[UU_2D][P33] += signx[UU_2D]*q[UU_2D][Q133]/(2.0*dx)
-    + signy[UU_2D]*q[UU_2D][Q233]/(2.0*dy);
-  
   double da = fmin(dx, dy);
   double cfla = dt/(da*da);
   cflrate[0] = alpha*vth_avg*cfla;
 }
 
 void
+grad_closure_update_2d(const gkyl_ten_moment_grad_closure *gces,
+  const double *q[], double *rhs)
+{
+  double div_qx[6] = {0.0};
+  double div_qy[6] = {0.0};
+
+  const double dx = gces->grid.dx[0];
+  const double dy = gces->grid.dx[1];
+
+  div_qx[0] = calc_sym_gradx_2D(dx, q[LL_2D][UU_2D*10 + Q111],
+    q[LU_2D][UL_2D*10 + Q111], q[UL_2D][LU_2D*10 + Q111], q[UU_2D][LL_2D*10 + Q111]);
+  div_qx[1] = calc_sym_gradx_2D(dx, q[LL_2D][UU_2D*10 + Q112],
+    q[LU_2D][UL_2D*10 + Q112], q[UL_2D][LU_2D*10 + Q112], q[UU_2D][LL_2D*10 + Q112]);
+  div_qx[2] = calc_sym_gradx_2D(dx, q[LL_2D][UU_2D*10 + Q113],
+    q[LU_2D][UL_2D*10 + Q113], q[UL_2D][LU_2D*10 + Q113], q[UU_2D][LL_2D*10 + Q113]);
+  div_qx[3] = calc_sym_gradx_2D(dx, q[LL_2D][UU_2D*10 + Q122],
+    q[LU_2D][UL_2D*10 + Q122], q[UL_2D][LU_2D*10 + Q122], q[UU_2D][LL_2D*10 + Q122]);
+  div_qx[4] = calc_sym_gradx_2D(dx, q[LL_2D][UU_2D*10 + Q123],
+    q[LU_2D][UL_2D*10 + Q123], q[UL_2D][LU_2D*10 + Q123], q[UU_2D][LL_2D*10 + Q123]);
+  div_qx[5] = calc_sym_gradx_2D(dx, q[LL_2D][UU_2D*10 + Q133],
+    q[LU_2D][UL_2D*10 + Q133], q[UL_2D][LU_2D*10 + Q133], q[UU_2D][LL_2D*10 + Q133]);
+
+  div_qy[0] = calc_sym_grady_2D(dy, q[LL_2D][UU_2D*10 + Q112],
+    q[LU_2D][UL_2D*10 + Q112], q[UL_2D][LU_2D*10 + Q112], q[UU_2D][LL_2D*10 + Q112]);
+  div_qy[1] = calc_sym_grady_2D(dy, q[LL_2D][UU_2D*10 + Q122],
+    q[LU_2D][UL_2D*10 + Q122], q[UL_2D][LU_2D*10 + Q122], q[UU_2D][LL_2D*10 + Q122]);
+  div_qy[2] = calc_sym_grady_2D(dy, q[LL_2D][UU_2D*10 + Q123],
+    q[LU_2D][UL_2D*10 + Q123], q[UL_2D][LU_2D*10 + Q123], q[UU_2D][LL_2D*10 + Q123]);
+  div_qy[3] = calc_sym_grady_2D(dy, q[LL_2D][UU_2D*10 + Q222],
+    q[LU_2D][UL_2D*10 + Q222], q[UL_2D][LU_2D*10 + Q222], q[UU_2D][LL_2D*10 + Q222]);
+  div_qy[4] = calc_sym_grady_2D(dy, q[LL_2D][UU_2D*10 + Q223],
+    q[LU_2D][UL_2D*10 + Q223], q[UL_2D][LU_2D*10 + Q223], q[UU_2D][LL_2D*10 + Q223]);
+  div_qy[5] = calc_sym_grady_2D(dy, q[LL_2D][UU_2D*10 + Q233],
+    q[LU_2D][UL_2D*10 + Q233], q[UL_2D][LU_2D*10 + Q233], q[UU_2D][LL_2D*10 + Q233]);
+
+  rhs[RHO] = 0.0;
+  rhs[MX] = 0.0;
+  rhs[MY] = 0.0;
+  rhs[MZ] = 0.0;
+  rhs[P11] = div_qx[0] + div_qy[0];
+  rhs[P12] = div_qx[1] + div_qy[1];
+  rhs[P13] = div_qx[2] + div_qy[2];
+  rhs[P22] = div_qx[3] + div_qy[3];
+  rhs[P23] = div_qx[4] + div_qy[4];
+  rhs[P33] = div_qx[5] + div_qy[5];
+}
+
+void
 calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double dt, double *rhs_d[])
+  const double *fluid_d[], double *cflrate, double dt, double *q)
 {
   const int ndim = gces->ndim;
   double rho_avg = 0.0;
@@ -377,7 +395,6 @@ calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
   double Tij[8][6] = {0.0};
   double rho[8] = {0.0};
   double p[8] = {0.0};
-  double q[8][10] = {0.0};
   var_setup(gces, LLL_3D, UUU_3D, fluid_d, rho, p, Tij);
 
   rho_avg = calc_harmonic_avg_3D(rho[LLL_3D], rho[LLU_3D], rho[LUL_3D], rho[LUU_3D],
@@ -636,317 +653,252 @@ calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
   int compy[8] = { LL_2D, UL_2D, LL_2D, UL_2D, LU_2D, UU_2D, LU_2D, UU_2D };
   int compz[8] = { LL_2D, LL_2D, UL_2D, UL_2D, LU_2D, LU_2D, UU_2D, UU_2D };
 
-  int signx[8] = { 1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0 };
-  int signy[8] = { 1.0, 1.0, -1.0, -1.0, 1.0, 1.0, -1.0, -1.0 };
-  int signz[8] = { 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0 };
-
-
-  q[LLL_3D][Q111] = chi*dTdx[compx[LLL_3D]][T11];
-  q[LLL_3D][Q112] = chi*(2.0*dTdx[compx[LLL_3D]][T12]
+  q[LLL_3D*10 + Q111] = chi*dTdx[compx[LLL_3D]][T11];
+  q[LLL_3D*10 + Q112] = chi*(2.0*dTdx[compx[LLL_3D]][T12]
     + dTdy[compy[LLL_3D]][T11])/3.0;
-  q[LLL_3D][Q113] = chi*(2.0*dTdx[compx[LLL_3D]][T13]
+  q[LLL_3D*10 + Q113] = chi*(2.0*dTdx[compx[LLL_3D]][T13]
     + dTdz[compz[LLL_3D]][T11])/3.0;
-  q[LLL_3D][Q122] = chi*(dTdx[compx[LLL_3D]][T22]
+  q[LLL_3D*10 + Q122] = chi*(dTdx[compx[LLL_3D]][T22]
     + 2.0*dTdy[compy[LLL_3D]][T12])/3.0;
-  q[LLL_3D][Q123] = chi*(dTdx[compx[LLL_3D]][T23]
+  q[LLL_3D*10 + Q123] = chi*(dTdx[compx[LLL_3D]][T23]
     + dTdy[compy[LLL_3D]][T13] + dTdz[compz[LLL_3D]][T12])/3.0;
-  q[LLL_3D][Q133] = chi*(dTdx[compx[LLL_3D]][T33]
+  q[LLL_3D*10 + Q133] = chi*(dTdx[compx[LLL_3D]][T33]
     + 2.0*dTdz[compz[LLL_3D]][T13])/3.0;
-  q[LLL_3D][Q222] = chi*dTdy[compy[LLL_3D]][T22];
-  q[LLL_3D][Q223] = chi*(2.0*dTdy[compy[LLL_3D]][T23]
+  q[LLL_3D*10 + Q222] = chi*dTdy[compy[LLL_3D]][T22];
+  q[LLL_3D*10 + Q223] = chi*(2.0*dTdy[compy[LLL_3D]][T23]
     + dTdz[compz[LLL_3D]][T22])/3.0;
-  q[LLL_3D][Q233] = chi*(dTdy[compy[LLL_3D]][T33]
+  q[LLL_3D*10 + Q233] = chi*(dTdy[compy[LLL_3D]][T33]
     + 2.0*dTdz[compz[LLL_3D]][T23])/3.0;
-  q[LLL_3D][Q333] = chi*dTdz[compz[LLL_3D]][T33];
+  q[LLL_3D*10 + Q333] = chi*dTdz[compz[LLL_3D]][T33];
 
-  q[LLU_3D][Q111] = chi*dTdx[compx[LLU_3D]][T11];
-  q[LLU_3D][Q112] = chi*(2.0*dTdx[compx[LLU_3D]][T12]
+  q[LLU_3D*10 + Q111] = chi*dTdx[compx[LLU_3D]][T11];
+  q[LLU_3D*10 + Q112] = chi*(2.0*dTdx[compx[LLU_3D]][T12]
     + dTdy[compy[LLU_3D]][T11])/3.0;
-  q[LLU_3D][Q113] = chi*(2.0*dTdx[compx[LLU_3D]][T13]
+  q[LLU_3D*10 + Q113] = chi*(2.0*dTdx[compx[LLU_3D]][T13]
     + dTdz[compz[LLU_3D]][T11])/3.0;
-  q[LLU_3D][Q122] = chi*(dTdx[compx[LLU_3D]][T22]
+  q[LLU_3D*10 + Q122] = chi*(dTdx[compx[LLU_3D]][T22]
     + 2.0*dTdy[compy[LLU_3D]][T12])/3.0;
-  q[LLU_3D][Q123] = chi*(dTdx[compx[LLU_3D]][T23]
+  q[LLU_3D*10 + Q123] = chi*(dTdx[compx[LLU_3D]][T23]
     + dTdy[compy[LLU_3D]][T13] + dTdz[compz[LLU_3D]][T12])/3.0;
-  q[LLU_3D][Q133] = chi*(dTdx[compx[LLU_3D]][T33]
+  q[LLU_3D*10 + Q133] = chi*(dTdx[compx[LLU_3D]][T33]
     + 2.0*dTdz[compz[LLU_3D]][T13])/3.0;
-  q[LLU_3D][Q222] = chi*dTdy[compy[LLU_3D]][T22];
-  q[LLU_3D][Q223] = chi*(2.0*dTdy[compy[LLU_3D]][T23]
+  q[LLU_3D*10 + Q222] = chi*dTdy[compy[LLU_3D]][T22];
+  q[LLU_3D*10 + Q223] = chi*(2.0*dTdy[compy[LLU_3D]][T23]
     + dTdz[compz[LLU_3D]][T22])/3.0;
-  q[LLU_3D][Q233] = chi*(dTdy[compy[LLU_3D]][T33]
+  q[LLU_3D*10 + Q233] = chi*(dTdy[compy[LLU_3D]][T33]
     + 2.0*dTdz[compz[LLU_3D]][T23])/3.0;
-  q[LLU_3D][Q333] = chi*dTdz[compz[LLU_3D]][T33];
+  q[LLU_3D*10 + Q333] = chi*dTdz[compz[LLU_3D]][T33];
 
- q[LUL_3D][Q111] = chi*dTdx[compx[LUL_3D]][T11];
-  q[LUL_3D][Q112] = chi*(2.0*dTdx[compx[LUL_3D]][T12]
+  q[LUL_3D*10 + Q111] = chi*dTdx[compx[LUL_3D]][T11];
+  q[LUL_3D*10 + Q112] = chi*(2.0*dTdx[compx[LUL_3D]][T12]
     + dTdy[compy[LUL_3D]][T11])/3.0;
-  q[LUL_3D][Q113] = chi*(2.0*dTdx[compx[LUL_3D]][T13]
+  q[LUL_3D*10 + Q113] = chi*(2.0*dTdx[compx[LUL_3D]][T13]
     + dTdz[compz[LUL_3D]][T11])/3.0;
-  q[LUL_3D][Q122] = chi*(dTdx[compx[LUL_3D]][T22]
+  q[LUL_3D*10 + Q122] = chi*(dTdx[compx[LUL_3D]][T22]
     + 2.0*dTdy[compy[LUL_3D]][T12])/3.0;
-  q[LUL_3D][Q123] = chi*(dTdx[compx[LUL_3D]][T23]
+  q[LUL_3D*10 + Q123] = chi*(dTdx[compx[LUL_3D]][T23]
     + dTdy[compy[LUL_3D]][T13] + dTdz[compz[LUL_3D]][T12])/3.0;
-  q[LUL_3D][Q133] = chi*(dTdx[compx[LUL_3D]][T33]
+  q[LUL_3D*10 + Q133] = chi*(dTdx[compx[LUL_3D]][T33]
     + 2.0*dTdz[compz[LUL_3D]][T13])/3.0;
-  q[LUL_3D][Q222] = chi*dTdy[compy[LUL_3D]][T22];
-  q[LUL_3D][Q223] = chi*(2.0*dTdy[compy[LUL_3D]][T23]
+  q[LUL_3D*10 + Q222] = chi*dTdy[compy[LUL_3D]][T22];
+  q[LUL_3D*10 + Q223] = chi*(2.0*dTdy[compy[LUL_3D]][T23]
     + dTdz[compz[LUL_3D]][T22])/3.0;
-  q[LUL_3D][Q233] = chi*(dTdy[compy[LUL_3D]][T33]
+  q[LUL_3D*10 + Q233] = chi*(dTdy[compy[LUL_3D]][T33]
     + 2.0*dTdz[compz[LUL_3D]][T23])/3.0;
-  q[LUL_3D][Q333] = chi*dTdz[compz[LUL_3D]][T33];
+  q[LUL_3D*10 + Q333] = chi*dTdz[compz[LUL_3D]][T33];
 
- q[LUU_3D][Q111] = chi*dTdx[compx[LUU_3D]][T11];
-  q[LUU_3D][Q112] = chi*(2.0*dTdx[compx[LUU_3D]][T12]
+  q[LUU_3D*10 + Q111] = chi*dTdx[compx[LUU_3D]][T11];
+  q[LUU_3D*10 + Q112] = chi*(2.0*dTdx[compx[LUU_3D]][T12]
     + dTdy[compy[LUU_3D]][T11])/3.0;
-  q[LUU_3D][Q113] = chi*(2.0*dTdx[compx[LUU_3D]][T13]
+  q[LUU_3D*10 + Q113] = chi*(2.0*dTdx[compx[LUU_3D]][T13]
     + dTdz[compz[LUU_3D]][T11])/3.0;
-  q[LUU_3D][Q122] = chi*(dTdx[compx[LUU_3D]][T22]
+  q[LUU_3D*10 + Q122] = chi*(dTdx[compx[LUU_3D]][T22]
     + 2.0*dTdy[compy[LUU_3D]][T12])/3.0;
-  q[LUU_3D][Q123] = chi*(dTdx[compx[LUU_3D]][T23]
+  q[LUU_3D*10 + Q123] = chi*(dTdx[compx[LUU_3D]][T23]
     + dTdy[compy[LUU_3D]][T13] + dTdz[compz[LUU_3D]][T12])/3.0;
-  q[LUU_3D][Q133] = chi*(dTdx[compx[LUU_3D]][T33]
+  q[LUU_3D*10 + Q133] = chi*(dTdx[compx[LUU_3D]][T33]
     + 2.0*dTdz[compz[LUU_3D]][T13])/3.0;
-  q[LUU_3D][Q222] = chi*dTdy[compy[LUU_3D]][T22];
-  q[LUU_3D][Q223] = chi*(2.0*dTdy[compy[LUU_3D]][T23]
+  q[LUU_3D*10 + Q222] = chi*dTdy[compy[LUU_3D]][T22];
+  q[LUU_3D*10 + Q223] = chi*(2.0*dTdy[compy[LUU_3D]][T23]
     + dTdz[compz[LUU_3D]][T22])/3.0;
-  q[LUU_3D][Q233] = chi*(dTdy[compy[LUU_3D]][T33]
+  q[LUU_3D*10 + Q233] = chi*(dTdy[compy[LUU_3D]][T33]
     + 2.0*dTdz[compz[LUU_3D]][T23])/3.0;
-  q[LUU_3D][Q333] = chi*dTdz[compz[LUU_3D]][T33];
+  q[LUU_3D*10 + Q333] = chi*dTdz[compz[LUU_3D]][T33];
 
- q[ULL_3D][Q111] = chi*dTdx[compx[ULL_3D]][T11];
-  q[ULL_3D][Q112] = chi*(2.0*dTdx[compx[ULL_3D]][T12]
+  q[ULL_3D*10 + Q111] = chi*dTdx[compx[ULL_3D]][T11];
+  q[ULL_3D*10 + Q112] = chi*(2.0*dTdx[compx[ULL_3D]][T12]
     + dTdy[compy[ULL_3D]][T11])/3.0;
-  q[ULL_3D][Q113] = chi*(2.0*dTdx[compx[ULL_3D]][T13]
+  q[ULL_3D*10 + Q113] = chi*(2.0*dTdx[compx[ULL_3D]][T13]
     + dTdz[compz[ULL_3D]][T11])/3.0;
-  q[ULL_3D][Q122] = chi*(dTdx[compx[ULL_3D]][T22]
+  q[ULL_3D*10 + Q122] = chi*(dTdx[compx[ULL_3D]][T22]
     + 2.0*dTdy[compy[ULL_3D]][T12])/3.0;
-  q[ULL_3D][Q123] = chi*(dTdx[compx[ULL_3D]][T23]
+  q[ULL_3D*10 + Q123] = chi*(dTdx[compx[ULL_3D]][T23]
     + dTdy[compy[ULL_3D]][T13] + dTdz[compz[ULL_3D]][T12])/3.0;
-  q[ULL_3D][Q133] = chi*(dTdx[compx[ULL_3D]][T33]
+  q[ULL_3D*10 + Q133] = chi*(dTdx[compx[ULL_3D]][T33]
     + 2.0*dTdz[compz[ULL_3D]][T13])/3.0;
-  q[ULL_3D][Q222] = chi*dTdy[compy[ULL_3D]][T22];
-  q[ULL_3D][Q223] = chi*(2.0*dTdy[compy[ULL_3D]][T23]
+  q[ULL_3D*10 + Q222] = chi*dTdy[compy[ULL_3D]][T22];
+  q[ULL_3D*10 + Q223] = chi*(2.0*dTdy[compy[ULL_3D]][T23]
     + dTdz[compz[ULL_3D]][T22])/3.0;
-  q[ULL_3D][Q233] = chi*(dTdy[compy[ULL_3D]][T33]
+  q[ULL_3D*10 + Q233] = chi*(dTdy[compy[ULL_3D]][T33]
     + 2.0*dTdz[compz[ULL_3D]][T23])/3.0;
-  q[ULL_3D][Q333] = chi*dTdz[compz[ULL_3D]][T33];
+  q[ULL_3D*10 + Q333] = chi*dTdz[compz[ULL_3D]][T33];
 
-  q[ULU_3D][Q111] = chi*dTdx[compx[ULU_3D]][T11];
-  q[ULU_3D][Q112] = chi*(2.0*dTdx[compx[ULU_3D]][T12]
+  q[ULU_3D*10 + Q111] = chi*dTdx[compx[ULU_3D]][T11];
+  q[ULU_3D*10 + Q112] = chi*(2.0*dTdx[compx[ULU_3D]][T12]
     + dTdy[compy[ULU_3D]][T11])/3.0;
-  q[ULU_3D][Q113] = chi*(2.0*dTdx[compx[ULU_3D]][T13]
+  q[ULU_3D*10 + Q113] = chi*(2.0*dTdx[compx[ULU_3D]][T13]
     + dTdz[compz[ULU_3D]][T11])/3.0;
-  q[ULU_3D][Q122] = chi*(dTdx[compx[ULU_3D]][T22]
+  q[ULU_3D*10 + Q122] = chi*(dTdx[compx[ULU_3D]][T22]
     + 2.0*dTdy[compy[ULU_3D]][T12])/3.0;
-  q[ULU_3D][Q123] = chi*(dTdx[compx[ULU_3D]][T23]
+  q[ULU_3D*10 + Q123] = chi*(dTdx[compx[ULU_3D]][T23]
     + dTdy[compy[ULU_3D]][T13] + dTdz[compz[ULU_3D]][T12])/3.0;
-  q[ULU_3D][Q133] = chi*(dTdx[compx[ULU_3D]][T33]
+  q[ULU_3D*10 + Q133] = chi*(dTdx[compx[ULU_3D]][T33]
     + 2.0*dTdz[compz[ULU_3D]][T13])/3.0;
-  q[ULU_3D][Q222] = chi*dTdy[compy[ULU_3D]][T22];
-  q[ULU_3D][Q223] = chi*(2.0*dTdy[compy[ULU_3D]][T23]
+  q[ULU_3D*10 + Q222] = chi*dTdy[compy[ULU_3D]][T22];
+  q[ULU_3D*10 + Q223] = chi*(2.0*dTdy[compy[ULU_3D]][T23]
     + dTdz[compz[ULU_3D]][T22])/3.0;
-  q[ULU_3D][Q233] = chi*(dTdy[compy[ULU_3D]][T33]
+  q[ULU_3D*10 + Q233] = chi*(dTdy[compy[ULU_3D]][T33]
     + 2.0*dTdz[compz[ULU_3D]][T23])/3.0;
-  q[ULU_3D][Q333] = chi*dTdz[compz[ULU_3D]][T33];
+  q[ULU_3D*10 + Q333] = chi*dTdz[compz[ULU_3D]][T33];
 
-  q[UUL_3D][Q111] = chi*dTdx[compx[UUL_3D]][T11];
-  q[UUL_3D][Q112] = chi*(2.0*dTdx[compx[UUL_3D]][T12]
+  q[UUL_3D*10 + Q111] = chi*dTdx[compx[UUL_3D]][T11];
+  q[UUL_3D*10 + Q112] = chi*(2.0*dTdx[compx[UUL_3D]][T12]
     + dTdy[compy[UUL_3D]][T11])/3.0;
-  q[UUL_3D][Q113] = chi*(2.0*dTdx[compx[UUL_3D]][T13]
+  q[UUL_3D*10 + Q113] = chi*(2.0*dTdx[compx[UUL_3D]][T13]
     + dTdz[compz[UUL_3D]][T11])/3.0;
-  q[UUL_3D][Q122] = chi*(dTdx[compx[UUL_3D]][T22]
+  q[UUL_3D*10 + Q122] = chi*(dTdx[compx[UUL_3D]][T22]
     + 2.0*dTdy[compy[UUL_3D]][T12])/3.0;
-  q[UUL_3D][Q123] = chi*(dTdx[compx[UUL_3D]][T23]
+  q[UUL_3D*10 + Q123] = chi*(dTdx[compx[UUL_3D]][T23]
     + dTdy[compy[UUL_3D]][T13] + dTdz[compz[UUL_3D]][T12])/3.0;
-  q[UUL_3D][Q133] = chi*(dTdx[compx[UUL_3D]][T33]
+  q[UUL_3D*10 + Q133] = chi*(dTdx[compx[UUL_3D]][T33]
     + 2.0*dTdz[compz[UUL_3D]][T13])/3.0;
-  q[UUL_3D][Q222] = chi*dTdy[compy[UUL_3D]][T22];
-  q[UUL_3D][Q223] = chi*(2.0*dTdy[compy[UUL_3D]][T23]
+  q[UUL_3D*10 + Q222] = chi*dTdy[compy[UUL_3D]][T22];
+  q[UUL_3D*10 + Q223] = chi*(2.0*dTdy[compy[UUL_3D]][T23]
     + dTdz[compz[UUL_3D]][T22])/3.0;
-  q[UUL_3D][Q233] = chi*(dTdy[compy[UUL_3D]][T33]
+  q[UUL_3D*10 + Q233] = chi*(dTdy[compy[UUL_3D]][T33]
     + 2.0*dTdz[compz[UUL_3D]][T23])/3.0;
-  q[UUL_3D][Q333] = chi*dTdz[compz[UUL_3D]][T33];
+  q[UUL_3D*10 + Q333] = chi*dTdz[compz[UUL_3D]][T33];
 
-  q[UUU_3D][Q111] = chi*dTdx[compx[UUU_3D]][T11];
-  q[UUU_3D][Q112] = chi*(2.0*dTdx[compx[UUU_3D]][T12]
+  q[UUU_3D*10 + Q111] = chi*dTdx[compx[UUU_3D]][T11];
+  q[UUU_3D*10 + Q112] = chi*(2.0*dTdx[compx[UUU_3D]][T12]
     + dTdy[compy[UUU_3D]][T11])/3.0;
-  q[UUU_3D][Q113] = chi*(2.0*dTdx[compx[UUU_3D]][T13]
+  q[UUU_3D*10 + Q113] = chi*(2.0*dTdx[compx[UUU_3D]][T13]
     + dTdz[compz[UUU_3D]][T11])/3.0;
-  q[UUU_3D][Q122] = chi*(dTdx[compx[UUU_3D]][T22]
+  q[UUU_3D*10 + Q122] = chi*(dTdx[compx[UUU_3D]][T22]
     + 2.0*dTdy[compy[UUU_3D]][T12])/3.0;
-  q[UUU_3D][Q123] = chi*(dTdx[compx[UUU_3D]][T23]
+  q[UUU_3D*10 + Q123] = chi*(dTdx[compx[UUU_3D]][T23]
     + dTdy[compy[UUU_3D]][T13] + dTdz[compz[UUU_3D]][T12])/3.0;
-  q[UUU_3D][Q133] = chi*(dTdx[compx[UUU_3D]][T33]
+  q[UUU_3D*10 + Q133] = chi*(dTdx[compx[UUU_3D]][T33]
     + 2.0*dTdz[compz[UUU_3D]][T13])/3.0;
-  q[UUU_3D][Q222] = chi*dTdy[compy[UUU_3D]][T22];
-  q[UUU_3D][Q223] = chi*(2.0*dTdy[compy[UUU_3D]][T23]
+  q[UUU_3D*10 + Q222] = chi*dTdy[compy[UUU_3D]][T22];
+  q[UUU_3D*10 + Q223] = chi*(2.0*dTdy[compy[UUU_3D]][T23]
     + dTdz[compz[UUU_3D]][T22])/3.0;
-  q[UUU_3D][Q233] = chi*(dTdy[compy[UUU_3D]][T33]
+  q[UUU_3D*10 + Q233] = chi*(dTdy[compy[UUU_3D]][T33]
     + 2.0*dTdz[compz[UUU_3D]][T23])/3.0;
-  q[UUU_3D][Q333] = chi*dTdz[compz[UUU_3D]][T33];
-
-  rhs_d[LLL_3D][P11] += signx[LLL_3D]*q[LLL_3D][Q111]/(4.0*dx)
-    + signy[LLL_3D]*q[LLL_3D][Q112]/(4.0*dy)
-    + signz[LLL_3D]*q[LLL_3D][Q113]/(4.0*dz);
-  rhs_d[LLL_3D][P12] += signx[LLL_3D]*q[LLL_3D][Q112]/(4.0*dx)
-    + signy[LLL_3D]*q[LLL_3D][Q122]/(4.0*dy)
-    + signz[LLL_3D]*q[LLL_3D][Q123]/(4.0*dz);
-  rhs_d[LLL_3D][P13] += signx[LLL_3D]*q[LLL_3D][Q113]/(4.0*dx)
-    + signy[LLL_3D]*q[LLL_3D][Q123]/(4.0*dy)
-    + signz[LLL_3D]*q[LLL_3D][Q133]/(4.0*dz);
-  rhs_d[LLL_3D][P22] += signx[LLL_3D]*q[LLL_3D][Q122]/(4.0*dx)
-    + signy[LLL_3D]*q[LLL_3D][Q222]/(4.0*dy)
-    + signz[LLL_3D]*q[LLL_3D][Q223]/(4.0*dz);
-  rhs_d[LLL_3D][P23] += signx[LLL_3D]*q[LLL_3D][Q123]/(4.0*dx) 
-    + signy[LLL_3D]*q[LLL_3D][Q223]/(4.0*dy)
-    + signz[LLL_3D]*q[LLL_3D][Q233]/(4.0*dz);
-  rhs_d[LLL_3D][P33] += signx[LLL_3D]*q[LLL_3D][Q133]/(4.0*dx)
-    + signy[LLL_3D]*q[LLL_3D][Q233]/(4.0*dy)
-    + signz[LLL_3D]*q[LLL_3D][Q333]/(4.0*dz);
-
-  rhs_d[LLU_3D][P11] += signx[LLU_3D]*q[LLU_3D][Q111]/(4.0*dx)
-    + signy[LLU_3D]*q[LLU_3D][Q112]/(4.0*dy)
-    + signz[LLU_3D]*q[LLU_3D][Q113]/(4.0*dz);
-  rhs_d[LLU_3D][P12] += signx[LLU_3D]*q[LLU_3D][Q112]/(4.0*dx)
-    + signy[LLU_3D]*q[LLU_3D][Q122]/(4.0*dy)
-    + signz[LLU_3D]*q[LLU_3D][Q123]/(4.0*dz);
-  rhs_d[LLU_3D][P13] += signx[LLU_3D]*q[LLU_3D][Q113]/(4.0*dx)
-    + signy[LLU_3D]*q[LLU_3D][Q123]/(4.0*dy)
-    + signz[LLU_3D]*q[LLU_3D][Q133]/(4.0*dz);
-  rhs_d[LLU_3D][P22] += signx[LLU_3D]*q[LLU_3D][Q122]/(4.0*dx)
-    + signy[LLU_3D]*q[LLU_3D][Q222]/(4.0*dy)
-    + signz[LLU_3D]*q[LLU_3D][Q223]/(4.0*dz);
-  rhs_d[LLU_3D][P23] += signx[LLU_3D]*q[LLU_3D][Q123]/(4.0*dx) 
-    + signy[LLU_3D]*q[LLU_3D][Q223]/(4.0*dy)
-    + signz[LLU_3D]*q[LLU_3D][Q233]/(4.0*dz);
-  rhs_d[LLU_3D][P33] += signx[LLU_3D]*q[LLU_3D][Q133]/(4.0*dx)
-    + signy[LLU_3D]*q[LLU_3D][Q233]/(4.0*dy)
-    + signz[LLU_3D]*q[LLU_3D][Q333]/(4.0*dz);
-
-  rhs_d[LUL_3D][P11] += signx[LUL_3D]*q[LUL_3D][Q111]/(4.0*dx)
-    + signy[LUL_3D]*q[LUL_3D][Q112]/(4.0*dy)
-    + signz[LUL_3D]*q[LUL_3D][Q113]/(4.0*dz);
-  rhs_d[LUL_3D][P12] += signx[LUL_3D]*q[LUL_3D][Q112]/(4.0*dx)
-    + signy[LUL_3D]*q[LUL_3D][Q122]/(4.0*dy)
-    + signz[LUL_3D]*q[LUL_3D][Q123]/(4.0*dz);
-  rhs_d[LUL_3D][P13] += signx[LUL_3D]*q[LUL_3D][Q113]/(4.0*dx)
-    + signy[LUL_3D]*q[LUL_3D][Q123]/(4.0*dy)
-    + signz[LUL_3D]*q[LUL_3D][Q133]/(4.0*dz);
-  rhs_d[LUL_3D][P22] += signx[LUL_3D]*q[LUL_3D][Q122]/(4.0*dx)
-    + signy[LUL_3D]*q[LUL_3D][Q222]/(4.0*dy)
-    + signz[LUL_3D]*q[LUL_3D][Q223]/(4.0*dz);
-  rhs_d[LUL_3D][P23] += signx[LUL_3D]*q[LUL_3D][Q123]/(4.0*dx) 
-    + signy[LUL_3D]*q[LUL_3D][Q223]/(4.0*dy)
-    + signz[LUL_3D]*q[LUL_3D][Q233]/(4.0*dz);
-  rhs_d[LUL_3D][P33] += signx[LUL_3D]*q[LUL_3D][Q133]/(4.0*dx)
-    + signy[LUL_3D]*q[LUL_3D][Q233]/(4.0*dy)
-    + signz[LUL_3D]*q[LUL_3D][Q333]/(4.0*dz);
-
-  rhs_d[LUU_3D][P11] += signx[LUU_3D]*q[LUU_3D][Q111]/(4.0*dx)
-    + signy[LUU_3D]*q[LUU_3D][Q112]/(4.0*dy)
-    + signz[LUU_3D]*q[LUU_3D][Q113]/(4.0*dz);
-  rhs_d[LUU_3D][P12] += signx[LUU_3D]*q[LUU_3D][Q112]/(4.0*dx)
-    + signy[LUU_3D]*q[LUU_3D][Q122]/(4.0*dy)
-    + signz[LUU_3D]*q[LUU_3D][Q123]/(4.0*dz);
-  rhs_d[LUU_3D][P13] += signx[LUU_3D]*q[LUU_3D][Q113]/(4.0*dx)
-    + signy[LUU_3D]*q[LUU_3D][Q123]/(4.0*dy)
-    + signz[LUU_3D]*q[LUU_3D][Q133]/(4.0*dz);
-  rhs_d[LUU_3D][P22] += signx[LUU_3D]*q[LUU_3D][Q122]/(4.0*dx)
-    + signy[LUU_3D]*q[LUU_3D][Q222]/(4.0*dy)
-    + signz[LUU_3D]*q[LUU_3D][Q223]/(4.0*dz);
-  rhs_d[LUU_3D][P23] += signx[LUU_3D]*q[LUU_3D][Q123]/(4.0*dx) 
-    + signy[LUU_3D]*q[LUU_3D][Q223]/(4.0*dy)
-    + signz[LUU_3D]*q[LUU_3D][Q233]/(4.0*dz);
-  rhs_d[LUU_3D][P33] += signx[LUU_3D]*q[LUU_3D][Q133]/(4.0*dx)
-    + signy[LUU_3D]*q[LUU_3D][Q233]/(4.0*dy)
-    + signz[LUU_3D]*q[LUU_3D][Q333]/(4.0*dz);
-
-  rhs_d[ULL_3D][P11] += signx[ULL_3D]*q[ULL_3D][Q111]/(4.0*dx)
-    + signy[ULL_3D]*q[ULL_3D][Q112]/(4.0*dy)
-    + signz[ULL_3D]*q[ULL_3D][Q113]/(4.0*dz);
-  rhs_d[ULL_3D][P12] += signx[ULL_3D]*q[ULL_3D][Q112]/(4.0*dx)
-    + signy[ULL_3D]*q[ULL_3D][Q122]/(4.0*dy)
-    + signz[ULL_3D]*q[ULL_3D][Q123]/(4.0*dz);
-  rhs_d[ULL_3D][P13] += signx[ULL_3D]*q[ULL_3D][Q113]/(4.0*dx)
-    + signy[ULL_3D]*q[ULL_3D][Q123]/(4.0*dy)
-    + signz[ULL_3D]*q[ULL_3D][Q133]/(4.0*dz);
-  rhs_d[ULL_3D][P22] += signx[ULL_3D]*q[ULL_3D][Q122]/(4.0*dx)
-    + signy[ULL_3D]*q[ULL_3D][Q222]/(4.0*dy)
-    + signz[ULL_3D]*q[ULL_3D][Q223]/(4.0*dz);
-  rhs_d[ULL_3D][P23] += signx[ULL_3D]*q[ULL_3D][Q123]/(4.0*dx) 
-    + signy[ULL_3D]*q[ULL_3D][Q223]/(4.0*dy)
-    + signz[ULL_3D]*q[ULL_3D][Q233]/(4.0*dz);
-  rhs_d[ULL_3D][P33] += signx[ULL_3D]*q[ULL_3D][Q133]/(4.0*dx)
-    + signy[ULL_3D]*q[ULL_3D][Q233]/(4.0*dy)
-    + signz[ULL_3D]*q[ULL_3D][Q333]/(4.0*dz);
-
-  rhs_d[ULU_3D][P11] += signx[ULU_3D]*q[ULU_3D][Q111]/(4.0*dx)
-    + signy[ULU_3D]*q[ULU_3D][Q112]/(4.0*dy)
-    + signz[ULU_3D]*q[ULU_3D][Q113]/(4.0*dz);
-  rhs_d[ULU_3D][P12] += signx[ULU_3D]*q[ULU_3D][Q112]/(4.0*dx)
-    + signy[ULU_3D]*q[ULU_3D][Q122]/(4.0*dy)
-    + signz[ULU_3D]*q[ULU_3D][Q123]/(4.0*dz);
-  rhs_d[ULU_3D][P13] += signx[ULU_3D]*q[ULU_3D][Q113]/(4.0*dx)
-    + signy[ULU_3D]*q[ULU_3D][Q123]/(4.0*dy)
-    + signz[ULU_3D]*q[ULU_3D][Q133]/(4.0*dz);
-  rhs_d[ULU_3D][P22] += signx[ULU_3D]*q[ULU_3D][Q122]/(4.0*dx)
-    + signy[ULU_3D]*q[ULU_3D][Q222]/(4.0*dy)
-    + signz[ULU_3D]*q[ULU_3D][Q223]/(4.0*dz);
-  rhs_d[ULU_3D][P23] += signx[ULU_3D]*q[ULU_3D][Q123]/(4.0*dx) 
-    + signy[ULU_3D]*q[ULU_3D][Q223]/(4.0*dy)
-    + signz[ULU_3D]*q[ULU_3D][Q233]/(4.0*dz);
-  rhs_d[ULU_3D][P33] += signx[ULU_3D]*q[ULU_3D][Q133]/(4.0*dx)
-    + signy[ULU_3D]*q[ULU_3D][Q233]/(4.0*dy)
-    + signz[ULU_3D]*q[ULU_3D][Q333]/(4.0*dz);
-
-  rhs_d[UUL_3D][P11] += signx[UUL_3D]*q[UUL_3D][Q111]/(4.0*dx)
-    + signy[UUL_3D]*q[UUL_3D][Q112]/(4.0*dy)
-    + signz[UUL_3D]*q[UUL_3D][Q113]/(4.0*dz);
-  rhs_d[UUL_3D][P12] += signx[UUL_3D]*q[UUL_3D][Q112]/(4.0*dx)
-    + signy[UUL_3D]*q[UUL_3D][Q122]/(4.0*dy)
-    + signz[UUL_3D]*q[UUL_3D][Q123]/(4.0*dz);
-  rhs_d[UUL_3D][P13] += signx[UUL_3D]*q[UUL_3D][Q113]/(4.0*dx)
-    + signy[UUL_3D]*q[UUL_3D][Q123]/(4.0*dy)
-    + signz[UUL_3D]*q[UUL_3D][Q133]/(4.0*dz);
-  rhs_d[UUL_3D][P22] += signx[UUL_3D]*q[UUL_3D][Q122]/(4.0*dx)
-    + signy[UUL_3D]*q[UUL_3D][Q222]/(4.0*dy)
-    + signz[UUL_3D]*q[UUL_3D][Q223]/(4.0*dz);
-  rhs_d[UUL_3D][P23] += signx[UUL_3D]*q[UUL_3D][Q123]/(4.0*dx) 
-    + signy[UUL_3D]*q[UUL_3D][Q223]/(4.0*dy)
-    + signz[UUL_3D]*q[UUL_3D][Q233]/(4.0*dz);
-  rhs_d[UUL_3D][P33] += signx[UUL_3D]*q[UUL_3D][Q133]/(4.0*dx)
-    + signy[UUL_3D]*q[UUL_3D][Q233]/(4.0*dy)
-    + signz[UUL_3D]*q[UUL_3D][Q333]/(4.0*dz);
-
-  rhs_d[UUU_3D][P11] += signx[UUU_3D]*q[UUU_3D][Q111]/(4.0*dx)
-    + signy[UUU_3D]*q[UUU_3D][Q112]/(4.0*dy)
-    + signz[UUU_3D]*q[UUU_3D][Q113]/(4.0*dz);
-  rhs_d[UUU_3D][P12] += signx[UUU_3D]*q[UUU_3D][Q112]/(4.0*dx)
-    + signy[UUU_3D]*q[UUU_3D][Q122]/(4.0*dy)
-    + signz[UUU_3D]*q[UUU_3D][Q123]/(4.0*dz);
-  rhs_d[UUU_3D][P13] += signx[UUU_3D]*q[UUU_3D][Q113]/(4.0*dx)
-    + signy[UUU_3D]*q[UUU_3D][Q123]/(4.0*dy)
-    + signz[UUU_3D]*q[UUU_3D][Q133]/(4.0*dz);
-  rhs_d[UUU_3D][P22] += signx[UUU_3D]*q[UUU_3D][Q122]/(4.0*dx)
-    + signy[UUU_3D]*q[UUU_3D][Q222]/(4.0*dy)
-    + signz[UUU_3D]*q[UUU_3D][Q223]/(4.0*dz);
-  rhs_d[UUU_3D][P23] += signx[UUU_3D]*q[UUU_3D][Q123]/(4.0*dx) 
-    + signy[UUU_3D]*q[UUU_3D][Q223]/(4.0*dy)
-    + signz[UUU_3D]*q[UUU_3D][Q233]/(4.0*dz);
-  rhs_d[UUU_3D][P33] += signx[UUU_3D]*q[UUU_3D][Q133]/(4.0*dx)
-    + signy[UUU_3D]*q[UUU_3D][Q233]/(4.0*dy)
-    + signz[UUU_3D]*q[UUU_3D][Q333]/(4.0*dz);
+  q[UUU_3D*10 + Q333] = chi*dTdz[compz[UUU_3D]][T33];
 
   double da = fmin(fmin(dx, dy), dz);
   double cfla = dt/(da*da);
   cflrate[0] = alpha*vth_avg*cfla;
 }
 
+void
+grad_closure_update_3d(const gkyl_ten_moment_grad_closure *gces,
+  const double *q[], double *rhs)
+{
+  double div_qx[6] = {0.0};
+  double div_qy[6] = {0.0};
+  double div_qz[6] = {0.0};
+
+  const double dx = gces->grid.dx[0];
+  const double dy = gces->grid.dx[1];
+  const double dz = gces->grid.dx[2];
+
+  div_qx[0] = calc_sym_gradx_3D(dx, q[LLL_3D][UUU_3D*10 + Q111],
+    q[LLU_3D][UUL_3D*10 + Q111], q[LUL_3D][ULU_3D*10 + Q111],
+    q[LUU_3D][ULL_3D*10 + Q111], q[ULL_3D][LUU_3D*10 + Q111],
+    q[ULU_3D][LUL_3D*10 + Q111], q[UUL_3D][LLU_3D*10 + Q111],
+    q[UUU_3D][LLL_3D*10 + Q111]);
+  div_qx[1] = calc_sym_gradx_3D(dx, q[LLL_3D][UUU_3D*10 + Q112],
+    q[LLU_3D][UUL_3D*10 + Q112], q[LUL_3D][ULU_3D*10 + Q112], q[LUU_3D][ULL_3D*10 + Q112], q[ULL_3D][LUU_3D*10 + Q112],
+    q[ULU_3D][LUL_3D*10 + Q112], q[UUL_3D][LLU_3D*10 + Q112], q[UUU_3D][LLL_3D*10 + Q112]);
+  div_qx[2] = calc_sym_gradx_3D(dx, q[LLL_3D][UUU_3D*10 + Q113], q[LLU_3D][UUL_3D*10 + Q113],
+    q[LUL_3D][ULU_3D*10 + Q113], q[LUU_3D][ULL_3D*10 + Q113], q[ULL_3D][LUU_3D*10 + Q113],
+    q[ULU_3D][LUL_3D*10 + Q113], q[UUL_3D][LLU_3D*10 + Q113], q[UUU_3D][LLL_3D*10 + Q113]);
+  div_qx[3] = calc_sym_gradx_3D(dx, q[LLL_3D][UUU_3D*10 + Q122], q[LLU_3D][UUL_3D*10 + Q122],
+    q[LUL_3D][ULU_3D*10 + Q122], q[LUU_3D][ULL_3D*10 + Q122], q[ULL_3D][LUU_3D*10 + Q122],
+    q[ULU_3D][LUL_3D*10 + Q122], q[UUL_3D][LLU_3D*10 + Q122], q[UUU_3D][LLL_3D*10 + Q122]);
+  div_qx[4] = calc_sym_gradx_3D(dx, q[LLL_3D][UUU_3D*10 + Q123], q[LLU_3D][UUL_3D*10 + Q123],
+    q[LUL_3D][ULU_3D*10 + Q123], q[LUU_3D][ULL_3D*10 + Q123], q[ULL_3D][LUU_3D*10 + Q123],
+    q[ULU_3D][LUL_3D*10 + Q123], q[UUL_3D][LLU_3D*10 + Q123], q[UUU_3D][LLL_3D*10 + Q123]);
+  div_qx[5] = calc_sym_gradx_3D(dx, q[LLL_3D][UUU_3D*10 + Q133], q[LLU_3D][UUL_3D*10 + Q133],
+    q[LUL_3D][ULU_3D*10 + Q133], q[LUU_3D][ULL_3D*10 + Q133], q[ULL_3D][LUU_3D*10 + Q133],
+    q[ULU_3D][LUL_3D*10 + Q133], q[UUL_3D][LLU_3D*10 + Q133], q[UUU_3D][LLL_3D*10 + Q133]);
+
+  div_qy[0] = calc_sym_grady_3D(dy, q[LLL_3D][UUU_3D*10 + Q112], q[LLU_3D][UUL_3D*10 + Q112],
+    q[LUL_3D][ULU_3D*10 + Q112], q[LUU_3D][ULL_3D*10 + Q112], q[ULL_3D][LUU_3D*10 + Q112],
+    q[ULU_3D][LUL_3D*10 + Q112], q[UUL_3D][LLU_3D*10 + Q112], q[UUU_3D][LLL_3D*10 + Q112]);
+  div_qy[1] = calc_sym_grady_3D(dy, q[LLL_3D][UUU_3D*10 + Q122], q[LLU_3D][UUL_3D*10 + Q122],
+    q[LUL_3D][ULU_3D*10 + Q122], q[LUU_3D][ULL_3D*10 + Q122], q[ULL_3D][LUU_3D*10 + Q122],
+    q[ULU_3D][LUL_3D*10 + Q122], q[UUL_3D][LLU_3D*10 + Q122], q[UUU_3D][LLL_3D*10 + Q122]);
+  div_qy[2] = calc_sym_grady_3D(dy, q[LLL_3D][UUU_3D*10 + Q123], q[LLU_3D][UUL_3D*10 + Q123],
+    q[LUL_3D][ULU_3D*10 + Q123], q[LUU_3D][ULL_3D*10 + Q123], q[ULL_3D][LUU_3D*10 + Q123],
+    q[ULU_3D][LUL_3D*10 + Q123], q[UUL_3D][LLU_3D*10 + Q123], q[UUU_3D][LLL_3D*10 + Q123]);
+  div_qy[3] = calc_sym_grady_3D(dy, q[LLL_3D][UUU_3D*10 + Q222], q[LLU_3D][UUL_3D*10 + Q222],
+    q[LUL_3D][ULU_3D*10 + Q222], q[LUU_3D][ULL_3D*10 + Q222], q[ULL_3D][LUU_3D*10 + Q222],
+    q[ULU_3D][LUL_3D*10 + Q222], q[UUL_3D][LLU_3D*10 + Q222], q[UUU_3D][LLL_3D*10 + Q222]);
+  div_qy[4] = calc_sym_grady_3D(dy, q[LLL_3D][UUU_3D*10 + Q223], q[LLU_3D][UUL_3D*10 + Q223],
+    q[LUL_3D][ULU_3D*10 + Q223], q[LUU_3D][ULL_3D*10 + Q223], q[ULL_3D][LUU_3D*10 + Q223],
+    q[ULU_3D][LUL_3D*10 + Q223], q[UUL_3D][LLU_3D*10 + Q223], q[UUU_3D][LLL_3D*10 + Q223]);
+  div_qy[5] = calc_sym_grady_3D(dy, q[LLL_3D][UUU_3D*10 + Q233], q[LLU_3D][UUL_3D*10 + Q233],
+    q[LUL_3D][ULU_3D*10 + Q233], q[LUU_3D][ULL_3D*10 + Q233], q[ULL_3D][LUU_3D*10 + Q233],
+    q[ULU_3D][LUL_3D*10 + Q233], q[UUL_3D][LLU_3D*10 + Q233], q[UUU_3D][LLL_3D*10 + Q233]);
+
+  div_qz[0] = calc_sym_gradz_3D(dz, q[LLL_3D][UUU_3D*10 + Q113], q[LLU_3D][UUL_3D*10 + Q113],
+    q[LUL_3D][ULU_3D*10 + Q113], q[LUU_3D][ULL_3D*10 + Q113], q[ULL_3D][LUU_3D*10 + Q113],
+    q[ULU_3D][LUL_3D*10 + Q113], q[UUL_3D][LLU_3D*10 + Q113], q[UUU_3D][LLL_3D*10 + Q113]);
+  div_qz[1] = calc_sym_gradz_3D(dz, q[LLL_3D][UUU_3D*10 + Q123], q[LLU_3D][UUL_3D*10 + Q123],
+    q[LUL_3D][ULU_3D*10 + Q123], q[LUU_3D][ULL_3D*10 + Q123], q[ULL_3D][LUU_3D*10 + Q123],
+    q[ULU_3D][LUL_3D*10 + Q123], q[UUL_3D][LLU_3D*10 + Q123], q[UUU_3D][LLL_3D*10 + Q123]);
+  div_qz[2] = calc_sym_gradz_3D(dz, q[LLL_3D][UUU_3D*10 + Q133], q[LLU_3D][UUL_3D*10 + Q133],
+    q[LUL_3D][ULU_3D*10 + Q133], q[LUU_3D][ULL_3D*10 + Q133], q[ULL_3D][LUU_3D*10 + Q133],
+    q[ULU_3D][LUL_3D*10 + Q133], q[UUL_3D][LLU_3D*10 + Q133], q[UUU_3D][LLL_3D*10 + Q133]);
+  div_qz[3] = calc_sym_gradz_3D(dz, q[LLL_3D][UUU_3D*10 + Q223], q[LLU_3D][UUL_3D*10 + Q223],
+    q[LUL_3D][ULU_3D*10 + Q223], q[LUU_3D][ULL_3D*10 + Q223], q[ULL_3D][LUU_3D*10 + Q223],
+    q[ULU_3D][LUL_3D*10 + Q223], q[UUL_3D][LLU_3D*10 + Q223], q[UUU_3D][LLL_3D*10 + Q223]);
+  div_qz[4] = calc_sym_gradz_3D(dz, q[LLL_3D][UUU_3D*10 + Q233], q[LLU_3D][UUL_3D*10 + Q233],
+    q[LUL_3D][ULU_3D*10 + Q233], q[LUU_3D][ULL_3D*10 + Q233], q[ULL_3D][LUU_3D*10 + Q233],
+    q[ULU_3D][LUL_3D*10 + Q233], q[UUL_3D][LLU_3D*10 + Q233], q[UUU_3D][LLL_3D*10 + Q233]);
+  div_qz[5] = calc_sym_gradz_3D(dz, q[LLL_3D][UUU_3D*10 + Q333], q[LLU_3D][UUL_3D*10 + Q333],
+    q[LUL_3D][ULU_3D*10 + Q333], q[LUU_3D][ULL_3D*10 + Q333], q[ULL_3D][LUU_3D*10 + Q333],
+    q[ULU_3D][LUL_3D*10 + Q333], q[UUL_3D][LLU_3D*10 + Q333], q[UUU_3D][LLL_3D*10 + Q333]);
+
+  rhs[RHO] = 0.0;
+  rhs[MX] = 0.0;
+  rhs[MY] = 0.0;
+  rhs[MZ] = 0.0;
+  rhs[P11] = div_qx[0] + div_qy[0] + div_qz[0];
+  rhs[P12] = div_qx[1] + div_qy[1] + div_qz[1];
+  rhs[P13] = div_qx[2] + div_qy[2] + div_qz[2];
+  rhs[P22] = div_qx[3] + div_qy[3] + div_qz[3];
+  rhs[P23] = div_qx[4] + div_qy[4] + div_qz[4];
+  rhs[P33] = div_qx[5] + div_qy[5] + div_qz[5];
+}
+
 static const heat_flux_calc_t grad_closure_unmag_funcs[3] = { calc_unmag_heat_flux_1d,
   calc_unmag_heat_flux_2d, calc_unmag_heat_flux_3d };
+
+static const heat_flux_update_t grad_closure_update_funcs[3] = { grad_closure_update_1d,
+  grad_closure_update_2d, grad_closure_update_3d };
 
 void
 grad_closure_calc_q_choose(struct gkyl_ten_moment_grad_closure *gces)
 {
   gces->calc_q = grad_closure_unmag_funcs[gces->ndim - 1];
+}
+
+void
+grad_closure_update_q_choose(struct gkyl_ten_moment_grad_closure *gces)
+{
+  gces->update_q = grad_closure_update_funcs[gces->ndim - 1];
 }

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -15,6 +15,8 @@ struct gkyl_ten_moment_grad_closure {
   bool use_gpu; // Boolean to determine whether wave equation object is on host or device
   
   struct gkyl_comm *comm;
+  long *offsets_centers;
+  long *offsets_vertices;
 
   heat_flux_calc_t calc_q;
   heat_flux_update_t update_q;
@@ -59,6 +61,40 @@ enum loc_3d {
   ULL_3D, ULU_3D,
   UUL_3D, UUU_3D
 };
+
+static void
+create_offsets_vertices(const struct gkyl_range *range, long offsets[])
+{
+  int arr1[3] = { -1, -1, -1 }, arr2[3] = { 0, 0, 0 };
+  // box spanning stencil
+  struct gkyl_range box3;
+  gkyl_range_init(&box3, range->ndim, arr1, arr2);
+
+  struct gkyl_range_iter iter3;
+  gkyl_range_iter_init(&iter3, &box3);
+
+  // construct list of offsets
+  int count = 0;
+  while (gkyl_range_iter_next(&iter3))
+    offsets[count++] = gkyl_range_offset(range, iter3.idx);
+}
+
+static void
+create_offsets_centers(const struct gkyl_range *range, long offsets[])
+{
+  int arr1[3] = { 0, 0, 0 }, arr2[3] = { 1, 1, 1 };
+  // box spanning stencil
+  struct gkyl_range box3;
+  gkyl_range_init(&box3, range->ndim, arr1, arr2);
+
+  struct gkyl_range_iter iter3;
+  gkyl_range_iter_init(&iter3, &box3);
+
+  // construct list of offsets
+  int count = 0;
+  while (gkyl_range_iter_next(&iter3))
+    offsets[count++] = gkyl_range_offset(range, iter3.idx);
+}
 
 GKYL_CU_D
 static void

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -8,6 +8,8 @@ struct gkyl_ten_moment_grad_closure {
   int ndim; // number of dimensions
   double k0; // damping coefficient
   double cfl; // CFL number to use
+  double *cfla;
+  
   struct gkyl_comm *comm;
 
   heat_flux_calc_t calc_q;

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -12,6 +12,7 @@ struct gkyl_ten_moment_grad_closure {
   double k0; // damping coefficient
   double cfl; // CFL number to use
   double *cfla;
+  int sz_idx;
   bool use_gpu; // Boolean to determine whether wave equation object is on host or device
   
   struct gkyl_comm *comm;

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -1,0 +1,954 @@
+#include <gkyl_moment_non_ideal_priv.h>
+
+typedef double (*heat_flux_calc_t)(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate, double cfl,
+  double dt, double *rhs_d[]);
+
+struct gkyl_ten_moment_grad_closure {
+  struct gkyl_rect_grid grid; // grid object
+  int ndim; // number of dimensions
+  double k0; // damping coefficient
+  double cfl; // CFL number to use
+  struct gkyl_comm *comm;
+
+  heat_flux_calc_t calc_q;
+};
+
+// Makes indexing cleaner
+static const unsigned T11 = 0;
+static const unsigned T12 = 1;
+static const unsigned T13 = 2;
+static const unsigned T22 = 3;
+static const unsigned T23 = 4;
+static const unsigned T33 = 5;
+
+static const unsigned Q111 = 0;
+static const unsigned Q112 = 1;
+static const unsigned Q113 = 2;
+static const unsigned Q122 = 3;
+static const unsigned Q123 = 4;
+static const unsigned Q133 = 5;
+static const unsigned Q222 = 6;
+static const unsigned Q223 = 7;
+static const unsigned Q233 = 8;
+static const unsigned Q333 = 9;
+
+// 1D stencil locations (L: lower, U: upper)
+enum loc_1d {
+  L_1D, U_1D
+};
+
+// 2D stencil locations (L: lower, U: upper)
+enum loc_2d {
+  LL_2D, LU_2D,
+  UL_2D, UU_2D
+};
+
+// 3D stencil locations (L: lower, U: upper)
+enum loc_3d {
+  LLL_3D, LLU_3D,
+  LUL_3D, LUU_3D,
+  ULL_3D, ULU_3D,
+  UUL_3D, UUU_3D
+};
+
+static void
+var_setup(const gkyl_ten_moment_grad_closure *gces,
+  int start, int end,
+  const double *fluid_d[],
+  double rho[], double p[], double Tij[][6])
+{
+  for (int j = start; j <= end; ++j) {
+    rho[j] = fluid_d[j][RHO];
+    p[j] = (fluid_d[j][P11] - fluid_d[j][MX]*fluid_d[j][MX]/fluid_d[j][RHO]
+          + fluid_d[j][P22] - fluid_d[j][MY]*fluid_d[j][MY]/fluid_d[j][RHO]
+          + fluid_d[j][P33] - fluid_d[j][MZ]*fluid_d[j][MZ]/fluid_d[j][RHO])/3.0;
+    Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX]*fluid_d[j][MX]/fluid_d[j][RHO])/fluid_d[j][RHO];
+    Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX]*fluid_d[j][MY]/fluid_d[j][RHO])/fluid_d[j][RHO];
+    Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX]*fluid_d[j][MZ]/fluid_d[j][RHO])/fluid_d[j][RHO];
+    Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY]*fluid_d[j][MY]/fluid_d[j][RHO])/fluid_d[j][RHO];
+    Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY]*fluid_d[j][MZ]/fluid_d[j][RHO])/fluid_d[j][RHO];
+    Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ]*fluid_d[j][MZ]/fluid_d[j][RHO])/fluid_d[j][RHO];
+  }
+}
+
+static inline double
+calc_sym_grad_limiter_2D(double alpha, double a, double b)
+{
+  double avg = (a + b)/2;
+  double min = fmin(alpha*a, a/alpha);
+  double max = fmax(alpha*a, a/alpha);
+  if (avg <= min) {
+    return min;
+  } else if (avg >= max) {
+    return max;
+  } else {
+    return avg;
+  }
+}
+
+static inline double
+calc_sym_grad_limiter_3D(double alpha, double a, double b, double c, double d)
+{
+  double avg = (a + b + c + d)/4;
+  double min = fmin(alpha*a, a/alpha);
+  double max = fmax(alpha*a, a/alpha);
+  if (avg <= min) {
+    return min;
+  } else if (avg >= max) {
+    return max;
+  } else {
+    return avg;
+  }
+}
+
+double
+calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate,
+  double cfl, double dt, double *rhs_d[])
+{
+  const int ndim = gces->ndim;
+  double rho_avg = 0.0;
+  double p_avg = 0.0;
+
+  const double dx = gces->grid.dx[0];
+  double dTdx[6] = {0.0};
+  double dTdy[6] = {0.0};
+  double dTdz[6] = {0.0};
+  double Tij[2][6] = {0.0};
+  double rho[2] = {0.0};
+  double p[2] = {0.0};
+  double q[10] = {0.0};
+  var_setup(gces, L_1D, U_1D, fluid_d, rho, p, Tij);
+
+  rho_avg = calc_harmonic_avg_1D(rho[L_1D], rho[U_1D]);
+  p_avg = calc_harmonic_avg_1D(p[L_1D], p[U_1D]);
+
+  dTdx[T11] = calc_sym_grad_1D(dx, Tij[L_1D][T11], Tij[U_1D][T11]);
+  dTdx[T12] = calc_sym_grad_1D(dx, Tij[L_1D][T12], Tij[U_1D][T12]);
+  dTdx[T13] = calc_sym_grad_1D(dx, Tij[L_1D][T13], Tij[U_1D][T13]);
+  dTdx[T22] = calc_sym_grad_1D(dx, Tij[L_1D][T22], Tij[U_1D][T22]);
+  dTdx[T23] = calc_sym_grad_1D(dx, Tij[L_1D][T23], Tij[U_1D][T23]);
+  dTdx[T33] = calc_sym_grad_1D(dx, Tij[L_1D][T33], Tij[U_1D][T33]);
+
+  double alpha = 1.0/gces->k0;
+  double vth_avg = sqrt(p_avg/rho_avg);
+  
+  // Temperature is actually T/m due to the formulation of var_setup.
+  // Thus, the mass density rho is used instead of number density n.
+  double chi = alpha*vth_avg*rho_avg;
+
+  q[Q111] = chi*dTdx[T11];
+  q[Q112] = chi*2.0*dTdx[T12]/3.0;
+  q[Q113] = chi*2.0*dTdx[T13]/3.0;
+  q[Q122] = chi*dTdx[T22]/3.0;
+  q[Q123] = chi*dTdx[T23]/3.0;
+  q[Q133] = chi*dTdx[T33]/3.0;
+
+  int signx[2] = { 1.0, -1.0 };
+  rhs_d[L_1D][P11] += signx[L_1D]*q[Q111]/dx;
+  rhs_d[L_1D][P12] += signx[L_1D]*q[Q112]/dx;
+  rhs_d[L_1D][P13] += signx[L_1D]*q[Q113]/dx;
+  rhs_d[L_1D][P22] += signx[L_1D]*q[Q122]/dx;
+  rhs_d[L_1D][P23] += signx[L_1D]*q[Q123]/dx;
+  rhs_d[L_1D][P33] += signx[L_1D]*q[Q133]/dx;
+
+  rhs_d[U_1D][P11] += signx[U_1D]*q[Q111]/dx;
+  rhs_d[U_1D][P12] += signx[U_1D]*q[Q112]/dx;
+  rhs_d[U_1D][P13] += signx[U_1D]*q[Q113]/dx;
+  rhs_d[U_1D][P22] += signx[U_1D]*q[Q122]/dx;
+  rhs_d[U_1D][P23] += signx[U_1D]*q[Q123]/dx;
+  rhs_d[U_1D][P33] += signx[U_1D]*q[Q133]/dx;
+
+  double cfla = dt/(dx*dx);
+  return fmax(alpha*vth_avg*cfla, cfl);
+}
+
+double
+calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate,
+  double cfl, double dt, double *rhs_d[])
+{
+  const int ndim = gces->ndim;
+  double rho_avg = 0.0;
+  double p_avg = 0.0;
+  double limit = 0.75;
+
+  const double dx = gces->grid.dx[0];
+  const double dy = gces->grid.dx[1];
+  double dTx[2][6] = {0.0};
+  double dTy[2][6] = {0.0};
+  double dTdx[2][6] = {0.0};
+  double dTdy[2][6] = {0.0};
+  double Tij[4][6] = {0.0};
+  double rho[4] = {0.0};
+  double p[4] = {0.0};
+  double q[4][10] = {0.0};
+  var_setup(gces, LL_2D, UU_2D, fluid_d, rho, p, Tij);
+
+  rho_avg = calc_harmonic_avg_2D(rho[LL_2D], rho[LU_2D], rho[UL_2D], rho[UU_2D]);
+  p_avg = calc_harmonic_avg_2D(p[LL_2D], p[LU_2D], p[UL_2D], p[UU_2D]);
+
+  dTx[L_1D][T11] = calc_sym_grad_1D(dx, Tij[LL_2D][T11], Tij[UL_2D][T11]);
+  dTx[L_1D][T12] = calc_sym_grad_1D(dx, Tij[LL_2D][T12], Tij[UL_2D][T12]);
+  dTx[L_1D][T13] = calc_sym_grad_1D(dx, Tij[LL_2D][T13], Tij[UL_2D][T13]);
+  dTx[L_1D][T22] = calc_sym_grad_1D(dx, Tij[LL_2D][T22], Tij[UL_2D][T22]);
+  dTx[L_1D][T23] = calc_sym_grad_1D(dx, Tij[LL_2D][T23], Tij[UL_2D][T23]);
+  dTx[L_1D][T33] = calc_sym_grad_1D(dx, Tij[LL_2D][T33], Tij[UL_2D][T33]);
+
+  dTx[U_1D][T11] = calc_sym_grad_1D(dx, Tij[LU_2D][T11], Tij[UU_2D][T11]);
+  dTx[U_1D][T12] = calc_sym_grad_1D(dx, Tij[LU_2D][T12], Tij[UU_2D][T12]);
+  dTx[U_1D][T13] = calc_sym_grad_1D(dx, Tij[LU_2D][T13], Tij[UU_2D][T13]);
+  dTx[U_1D][T22] = calc_sym_grad_1D(dx, Tij[LU_2D][T22], Tij[UU_2D][T22]);
+  dTx[U_1D][T23] = calc_sym_grad_1D(dx, Tij[LU_2D][T23], Tij[UU_2D][T23]);
+  dTx[U_1D][T33] = calc_sym_grad_1D(dx, Tij[LU_2D][T33], Tij[UU_2D][T33]);
+
+  dTdx[L_1D][T11] = calc_sym_grad_limiter_2D(limit, dTx[L_1D][T11], dTx[U_1D][T11]);
+  dTdx[L_1D][T12] = calc_sym_grad_limiter_2D(limit, dTx[L_1D][T12], dTx[U_1D][T12]);
+  dTdx[L_1D][T13] = calc_sym_grad_limiter_2D(limit, dTx[L_1D][T13], dTx[U_1D][T13]);
+  dTdx[L_1D][T22] = calc_sym_grad_limiter_2D(limit, dTx[L_1D][T22], dTx[U_1D][T22]);
+  dTdx[L_1D][T23] = calc_sym_grad_limiter_2D(limit, dTx[L_1D][T23], dTx[U_1D][T23]);
+  dTdx[L_1D][T33] = calc_sym_grad_limiter_2D(limit, dTx[L_1D][T33], dTx[U_1D][T33]);
+
+  dTdx[U_1D][T11] = calc_sym_grad_limiter_2D(limit, dTx[U_1D][T11], dTx[L_1D][T11]);
+  dTdx[U_1D][T12] = calc_sym_grad_limiter_2D(limit, dTx[U_1D][T12], dTx[L_1D][T12]);
+  dTdx[U_1D][T13] = calc_sym_grad_limiter_2D(limit, dTx[U_1D][T13], dTx[L_1D][T13]);
+  dTdx[U_1D][T22] = calc_sym_grad_limiter_2D(limit, dTx[U_1D][T22], dTx[L_1D][T22]);
+  dTdx[U_1D][T23] = calc_sym_grad_limiter_2D(limit, dTx[U_1D][T23], dTx[L_1D][T23]);
+  dTdx[U_1D][T33] = calc_sym_grad_limiter_2D(limit, dTx[U_1D][T33], dTx[L_1D][T33]);
+
+  dTy[L_1D][T11] = calc_sym_grad_1D(dy, Tij[LL_2D][T11], Tij[LU_2D][T11]);
+  dTy[L_1D][T12] = calc_sym_grad_1D(dy, Tij[LL_2D][T12], Tij[LU_2D][T12]);
+  dTy[L_1D][T13] = calc_sym_grad_1D(dy, Tij[LL_2D][T13], Tij[LU_2D][T13]);
+  dTy[L_1D][T22] = calc_sym_grad_1D(dy, Tij[LL_2D][T22], Tij[LU_2D][T22]);
+  dTy[L_1D][T23] = calc_sym_grad_1D(dy, Tij[LL_2D][T23], Tij[LU_2D][T23]);
+  dTy[L_1D][T33] = calc_sym_grad_1D(dy, Tij[LL_2D][T33], Tij[LU_2D][T33]);
+
+  dTy[U_1D][T11] = calc_sym_grad_1D(dy, Tij[UL_2D][T11], Tij[UU_2D][T11]);
+  dTy[U_1D][T12] = calc_sym_grad_1D(dy, Tij[UL_2D][T12], Tij[UU_2D][T12]);
+  dTy[U_1D][T13] = calc_sym_grad_1D(dy, Tij[UL_2D][T13], Tij[UU_2D][T13]);
+  dTy[U_1D][T22] = calc_sym_grad_1D(dy, Tij[UL_2D][T22], Tij[UU_2D][T22]);
+  dTy[U_1D][T23] = calc_sym_grad_1D(dy, Tij[UL_2D][T23], Tij[UU_2D][T23]);
+  dTy[U_1D][T33] = calc_sym_grad_1D(dy, Tij[UL_2D][T33], Tij[UU_2D][T33]);
+
+  dTdy[L_1D][T11] = calc_sym_grad_limiter_2D(limit, dTy[L_1D][T11], dTy[U_1D][T11]);
+  dTdy[L_1D][T12] = calc_sym_grad_limiter_2D(limit, dTy[L_1D][T12], dTy[U_1D][T12]);
+  dTdy[L_1D][T13] = calc_sym_grad_limiter_2D(limit, dTy[L_1D][T13], dTy[U_1D][T13]);
+  dTdy[L_1D][T22] = calc_sym_grad_limiter_2D(limit, dTy[L_1D][T22], dTy[U_1D][T22]);
+  dTdy[L_1D][T23] = calc_sym_grad_limiter_2D(limit, dTy[L_1D][T23], dTy[U_1D][T23]);
+  dTdy[L_1D][T33] = calc_sym_grad_limiter_2D(limit, dTy[L_1D][T33], dTy[U_1D][T33]);
+
+  dTdy[U_1D][T11] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T11], dTy[L_1D][T11]);
+  dTdy[U_1D][T12] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T12], dTy[L_1D][T12]);
+  dTdy[U_1D][T13] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T13], dTy[L_1D][T13]);
+  dTdy[U_1D][T22] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T22], dTy[L_1D][T22]);
+  dTdy[U_1D][T23] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T23], dTy[L_1D][T23]);
+  dTdy[U_1D][T33] = calc_sym_grad_limiter_2D(limit, dTy[U_1D][T33], dTy[L_1D][T33]);
+
+
+  double alpha = 1.0/gces->k0;
+  double vth_avg = sqrt(p_avg/rho_avg);
+
+  // Temperature is actually T/m due to the formulation of var_setup.
+  // Thus, the mass density rho is used instead of number density n.
+  double chi = alpha*vth_avg*rho_avg;
+
+  int compx[4] = { L_1D, U_1D, L_1D, U_1D };
+  int compy[4] = { L_1D, L_1D, U_1D, U_1D };
+
+  int signx[4] = { 1.0, 1.0, -1.0, -1.0 };
+  int signy[4] = { 1.0, -1.0, 1.0, -1.0 };
+
+  q[LL_2D][Q111] = chi*dTdx[compx[LL_2D]][T11];
+  q[LL_2D][Q112] = chi*(2.0*dTdx[compx[LL_2D]][T12] + dTdy[compy[LL_2D]][T11])/3.0;
+  q[LL_2D][Q113] = chi*2.0*dTdx[compx[LL_2D]][T13]/3.0;
+  q[LL_2D][Q122] = chi*(dTdx[compx[LL_2D]][T22] + 2.0*dTdy[compy[LL_2D]][T12])/3.0;
+  q[LL_2D][Q123] = chi*(dTdx[compx[LL_2D]][T23] + dTdy[compy[LL_2D]][T13])/3.0;
+  q[LL_2D][Q133] = chi*dTdx[compx[LL_2D]][T33]/3.0;
+  q[LL_2D][Q222] = chi*dTdy[compy[LL_2D]][T22];
+  q[LL_2D][Q223] = chi*2.0*dTdy[compy[LL_2D]][T23]/3.0;
+  q[LL_2D][Q233] = chi*dTdy[compy[LL_2D]][T33]/3.0;
+
+  q[LU_2D][Q111] = chi*dTdx[compx[LU_2D]][T11];
+  q[LU_2D][Q112] = chi*(2.0*dTdx[compx[LU_2D]][T12] + dTdy[compy[LU_2D]][T11])/3.0;
+  q[LU_2D][Q113] = chi*2.0*dTdx[compx[LU_2D]][T13]/3.0;
+  q[LU_2D][Q122] = chi*(dTdx[compx[LU_2D]][T22] + 2.0*dTdy[compy[LU_2D]][T12])/3.0;
+  q[LU_2D][Q123] = chi*(dTdx[compx[LU_2D]][T23] + dTdy[compy[LU_2D]][T13])/3.0;
+  q[LU_2D][Q133] = chi*dTdx[compx[LU_2D]][T33]/3.0;
+  q[LU_2D][Q222] = chi*dTdy[compy[LU_2D]][T22];
+  q[LU_2D][Q223] = chi*2.0*dTdy[compy[LU_2D]][T23]/3.0;
+  q[LU_2D][Q233] = chi*dTdy[compy[LU_2D]][T33]/3.0;
+
+  q[UL_2D][Q111] = chi*dTdx[compx[UL_2D]][T11];
+  q[UL_2D][Q112] = chi*(2.0*dTdx[compx[UL_2D]][T12] + dTdy[compy[UL_2D]][T11])/3.0;
+  q[UL_2D][Q113] = chi*2.0*dTdx[compx[UL_2D]][T13]/3.0;
+  q[UL_2D][Q122] = chi*(dTdx[compx[UL_2D]][T22] + 2.0*dTdy[compy[UL_2D]][T12])/3.0;
+  q[UL_2D][Q123] = chi*(dTdx[compx[UL_2D]][T23] + dTdy[compy[UL_2D]][T13])/3.0;
+  q[UL_2D][Q133] = chi*dTdx[compx[UL_2D]][T33]/3.0;
+  q[UL_2D][Q222] = chi*dTdy[compy[UL_2D]][T22];
+  q[UL_2D][Q223] = chi*2.0*dTdy[compy[UL_2D]][T23]/3.0;
+  q[UL_2D][Q233] = chi*dTdy[compy[UL_2D]][T33]/3.0;
+
+  q[UU_2D][Q111] = chi*dTdx[compx[UU_2D]][T11];
+  q[UU_2D][Q112] = chi*(2.0*dTdx[compx[UU_2D]][T12] + dTdy[compy[UU_2D]][T11])/3.0;
+  q[UU_2D][Q113] = chi*2.0*dTdx[compx[UU_2D]][T13]/3.0;
+  q[UU_2D][Q122] = chi*(dTdx[compx[UU_2D]][T22] + 2.0*dTdy[compy[UU_2D]][T12])/3.0;
+  q[UU_2D][Q123] = chi*(dTdx[compx[UU_2D]][T23] + dTdy[compy[UU_2D]][T13])/3.0;
+  q[UU_2D][Q133] = chi*dTdx[compx[UU_2D]][T33]/3.0;
+  q[UU_2D][Q222] = chi*dTdy[compy[UU_2D]][T22];
+  q[UU_2D][Q223] = chi*2.0*dTdy[compy[UU_2D]][T23]/3.0;
+  q[UU_2D][Q233] = chi*dTdy[compy[UU_2D]][T33]/3.0;
+
+  rhs_d[LL_2D][P11] += signx[LL_2D]*q[LL_2D][Q111]/(2.0*dx)
+    + signy[LL_2D]*q[LL_2D][Q112]/(2.0*dy);
+  rhs_d[LL_2D][P12] += signx[LL_2D]*q[LL_2D][Q112]/(2.0*dx)
+    + signy[LL_2D]*q[LL_2D][Q122]/(2.0*dy);
+  rhs_d[LL_2D][P13] += signx[LL_2D]*q[LL_2D][Q113]/(2.0*dx)
+    + signy[LL_2D]*q[LL_2D][Q123]/(2.0*dy);
+  rhs_d[LL_2D][P22] += signx[LL_2D]*q[LL_2D][Q122]/(2.0*dx)
+    + signy[LL_2D]*q[LL_2D][Q222]/(2.0*dy);
+  rhs_d[LL_2D][P23] += signx[LL_2D]*q[LL_2D][Q123]/(2.0*dx)
+    + signy[LL_2D]*q[LL_2D][Q223]/(2.0*dy);
+  rhs_d[LL_2D][P33] += signx[LL_2D]*q[LL_2D][Q133]/(2.0*dx)
+    + signy[LL_2D]*q[LL_2D][Q233]/(2.0*dy);
+
+  rhs_d[LU_2D][P11] += signx[LU_2D]*q[LU_2D][Q111]/(2.0*dx)
+    + signy[LU_2D]*q[LU_2D][Q112]/(2.0*dy);
+  rhs_d[LU_2D][P12] += signx[LU_2D]*q[LU_2D][Q112]/(2.0*dx)
+    + signy[LU_2D]*q[LU_2D][Q122]/(2.0*dy);
+  rhs_d[LU_2D][P13] += signx[LU_2D]*q[LU_2D][Q113]/(2.0*dx)
+    + signy[LU_2D]*q[LU_2D][Q123]/(2.0*dy);
+  rhs_d[LU_2D][P22] += signx[LU_2D]*q[LU_2D][Q122]/(2.0*dx)
+    + signy[LU_2D]*q[LU_2D][Q222]/(2.0*dy);
+  rhs_d[LU_2D][P23] += signx[LU_2D]*q[LU_2D][Q123]/(2.0*dx)
+    + signy[LU_2D]*q[LU_2D][Q223]/(2.0*dy);
+  rhs_d[LU_2D][P33] += signx[LU_2D]*q[LU_2D][Q133]/(2.0*dx)
+    + signy[LU_2D]*q[LU_2D][Q233]/(2.0*dy);
+
+  rhs_d[UL_2D][P11] += signx[UL_2D]*q[UL_2D][Q111]/(2.0*dx)
+    + signy[UL_2D]*q[UL_2D][Q112]/(2.0*dy);
+  rhs_d[UL_2D][P12] += signx[UL_2D]*q[UL_2D][Q112]/(2.0*dx)
+    + signy[UL_2D]*q[UL_2D][Q122]/(2.0*dy);
+  rhs_d[UL_2D][P13] += signx[UL_2D]*q[UL_2D][Q113]/(2.0*dx)
+    + signy[UL_2D]*q[UL_2D][Q123]/(2.0*dy);
+  rhs_d[UL_2D][P22] += signx[UL_2D]*q[UL_2D][Q122]/(2.0*dx)
+    + signy[UL_2D]*q[UL_2D][Q222]/(2.0*dy);
+  rhs_d[UL_2D][P23] += signx[UL_2D]*q[UL_2D][Q123]/(2.0*dx)
+    + signy[UL_2D]*q[UL_2D][Q223]/(2.0*dy);
+  rhs_d[UL_2D][P33] += signx[UL_2D]*q[UL_2D][Q133]/(2.0*dx)
+    + signy[UL_2D]*q[UL_2D][Q233]/(2.0*dy);
+
+  rhs_d[UU_2D][P11] += signx[UU_2D]*q[UU_2D][Q111]/(2.0*dx)
+    + signy[UU_2D]*q[UU_2D][Q112]/(2.0*dy);
+  rhs_d[UU_2D][P12] += signx[UU_2D]*q[UU_2D][Q112]/(2.0*dx)
+    + signy[UU_2D]*q[UU_2D][Q122]/(2.0*dy);
+  rhs_d[UU_2D][P13] += signx[UU_2D]*q[UU_2D][Q113]/(2.0*dx)
+    + signy[UU_2D]*q[UU_2D][Q123]/(2.0*dy);
+  rhs_d[UU_2D][P22] += signx[UU_2D]*q[UU_2D][Q122]/(2.0*dx)
+    + signy[UU_2D]*q[UU_2D][Q222]/(2.0*dy);
+  rhs_d[UU_2D][P23] += signx[UU_2D]*q[UU_2D][Q123]/(2.0*dx)
+    + signy[UU_2D]*q[UU_2D][Q223]/(2.0*dy);
+  rhs_d[UU_2D][P33] += signx[UU_2D]*q[UU_2D][Q133]/(2.0*dx)
+    + signy[UU_2D]*q[UU_2D][Q233]/(2.0*dy);
+  
+  double da = fmin(dx, dy);
+  double cfla = dt/(da*da);
+  return fmax(alpha*vth_avg*cfla, cfl);
+}
+
+double
+calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
+  const double *fluid_d[], double *cflrate,
+  double cfl, double dt, double *rhs_d[])
+{
+  const int ndim = gces->ndim;
+  double rho_avg = 0.0;
+  double p_avg = 0.0;
+  double limit = 0.75;
+
+  const double dx = gces->grid.dx[0];
+  const double dy = gces->grid.dx[1];
+  const double dz = gces->grid.dx[2];
+
+  double dTx[4][6] = {0.0};
+  double dTy[4][6] = {0.0};
+  double dTz[4][6] = {0.0};
+  double dTdx[4][6] = {0.0};
+  double dTdy[4][6] = {0.0};
+  double dTdz[4][6] = {0.0};
+  double Tij[8][6] = {0.0};
+  double rho[8] = {0.0};
+  double p[8] = {0.0};
+  double q[8][10] = {0.0};
+  var_setup(gces, LLL_3D, UUU_3D, fluid_d, rho, p, Tij);
+
+  rho_avg = calc_harmonic_avg_3D(rho[LLL_3D], rho[LLU_3D], rho[LUL_3D], rho[LUU_3D],
+                                 rho[ULL_3D], rho[ULU_3D], rho[UUL_3D], rho[UUU_3D]);
+  p_avg = calc_harmonic_avg_3D(p[LLL_3D], p[LLU_3D], p[LUL_3D], p[LUU_3D],
+                               p[ULL_3D], p[ULU_3D], p[UUL_3D], p[UUU_3D]);
+
+  dTx[LL_2D][T11] = calc_sym_grad_1D(dx, Tij[LLL_3D][T11], Tij[ULL_3D][T11]);
+  dTx[LL_2D][T12] = calc_sym_grad_1D(dx, Tij[LLL_3D][T12], Tij[ULL_3D][T12]);
+  dTx[LL_2D][T13] = calc_sym_grad_1D(dx, Tij[LLL_3D][T13], Tij[ULL_3D][T13]);
+  dTx[LL_2D][T22] = calc_sym_grad_1D(dx, Tij[LLL_3D][T22], Tij[ULL_3D][T22]);
+  dTx[LL_2D][T23] = calc_sym_grad_1D(dx, Tij[LLL_3D][T23], Tij[ULL_3D][T23]);
+  dTx[LL_2D][T33] = calc_sym_grad_1D(dx, Tij[LLL_3D][T33], Tij[ULL_3D][T33]);
+
+  dTx[LU_2D][T11] = calc_sym_grad_1D(dx, Tij[LUL_3D][T11], Tij[UUL_3D][T11]);
+  dTx[LU_2D][T12] = calc_sym_grad_1D(dx, Tij[LUL_3D][T12], Tij[UUL_3D][T12]);
+  dTx[LU_2D][T13] = calc_sym_grad_1D(dx, Tij[LUL_3D][T13], Tij[UUL_3D][T13]);
+  dTx[LU_2D][T22] = calc_sym_grad_1D(dx, Tij[LUL_3D][T22], Tij[UUL_3D][T22]);
+  dTx[LU_2D][T23] = calc_sym_grad_1D(dx, Tij[LUL_3D][T23], Tij[UUL_3D][T23]);
+  dTx[LU_2D][T33] = calc_sym_grad_1D(dx, Tij[LUL_3D][T33], Tij[UUL_3D][T33]);
+  
+  dTx[UL_2D][T11] = calc_sym_grad_1D(dx, Tij[LLU_3D][T11], Tij[ULU_3D][T11]);
+  dTx[UL_2D][T12] = calc_sym_grad_1D(dx, Tij[LLU_3D][T12], Tij[ULU_3D][T12]);
+  dTx[UL_2D][T13] = calc_sym_grad_1D(dx, Tij[LLU_3D][T13], Tij[ULU_3D][T13]);
+  dTx[UL_2D][T22] = calc_sym_grad_1D(dx, Tij[LLU_3D][T22], Tij[ULU_3D][T22]);
+  dTx[UL_2D][T23] = calc_sym_grad_1D(dx, Tij[LLU_3D][T23], Tij[ULU_3D][T23]);
+  dTx[UL_2D][T33] = calc_sym_grad_1D(dx, Tij[LLU_3D][T33], Tij[ULU_3D][T33]);
+  
+  dTx[UU_2D][T11] = calc_sym_grad_1D(dx, Tij[LUU_3D][T11], Tij[UUU_3D][T11]);
+  dTx[UU_2D][T12] = calc_sym_grad_1D(dx, Tij[LUU_3D][T12], Tij[UUU_3D][T12]);
+  dTx[UU_2D][T13] = calc_sym_grad_1D(dx, Tij[LUU_3D][T13], Tij[UUU_3D][T13]);
+  dTx[UU_2D][T22] = calc_sym_grad_1D(dx, Tij[LUU_3D][T22], Tij[UUU_3D][T22]);
+  dTx[UU_2D][T23] = calc_sym_grad_1D(dx, Tij[LUU_3D][T23], Tij[UUU_3D][T23]);  
+  dTx[UU_2D][T33] = calc_sym_grad_1D(dx, Tij[LUU_3D][T33], Tij[UUU_3D][T33]);
+
+  dTdx[LL_2D][T11] = calc_sym_grad_limiter_3D(limit, dTx[LL_2D][T11], dTx[LU_2D][T11],
+    dTx[UL_2D][T11], dTx[UU_2D][T11]);
+  dTdx[LL_2D][T12] = calc_sym_grad_limiter_3D(limit, dTx[LL_2D][T12], dTx[LU_2D][T12],
+    dTx[UL_2D][T12], dTx[UU_2D][T12]);
+  dTdx[LL_2D][T13] = calc_sym_grad_limiter_3D(limit, dTx[LL_2D][T13], dTx[LU_2D][T13],
+    dTx[UL_2D][T13], dTx[UU_2D][T13]);
+  dTdx[LL_2D][T22] = calc_sym_grad_limiter_3D(limit, dTx[LL_2D][T22], dTx[LU_2D][T22],
+    dTx[UL_2D][T22], dTx[UU_2D][T22]);
+  dTdx[LL_2D][T23] = calc_sym_grad_limiter_3D(limit, dTx[LL_2D][T23], dTx[LU_2D][T23],
+    dTx[UL_2D][T23], dTx[UU_2D][T23]);
+  dTdx[LL_2D][T33] = calc_sym_grad_limiter_3D(limit, dTx[LL_2D][T33], dTx[LU_2D][T33],
+    dTx[UL_2D][T33], dTx[UU_2D][T33]);
+
+  dTdx[LU_2D][T11] = calc_sym_grad_limiter_3D(limit, dTx[LU_2D][T11], dTx[LL_2D][T11],
+    dTx[UL_2D][T11], dTx[UU_2D][T11]);
+  dTdx[LU_2D][T12] = calc_sym_grad_limiter_3D(limit, dTx[LU_2D][T12], dTx[LL_2D][T12],
+    dTx[UL_2D][T12], dTx[UU_2D][T12]);
+  dTdx[LU_2D][T13] = calc_sym_grad_limiter_3D(limit, dTx[LU_2D][T13], dTx[LL_2D][T13],
+    dTx[UL_2D][T13], dTx[UU_2D][T13]);
+  dTdx[LU_2D][T22] = calc_sym_grad_limiter_3D(limit, dTx[LU_2D][T22], dTx[LL_2D][T22],
+    dTx[UL_2D][T22], dTx[UU_2D][T22]);
+  dTdx[LU_2D][T23] = calc_sym_grad_limiter_3D(limit, dTx[LU_2D][T23], dTx[LL_2D][T23],
+    dTx[UL_2D][T23], dTx[UU_2D][T23]);
+  dTdx[LU_2D][T33] = calc_sym_grad_limiter_3D(limit, dTx[LU_2D][T33], dTx[LL_2D][T33],
+    dTx[UL_2D][T33], dTx[UU_2D][T33]);
+
+  dTdx[UL_2D][T11] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T11], dTx[LL_2D][T11],
+    dTx[LU_2D][T11], dTx[UU_2D][T11]);
+  dTdx[UL_2D][T12] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T12], dTx[LL_2D][T12],
+    dTx[LU_2D][T12], dTx[UU_2D][T12]);
+  dTdx[UL_2D][T13] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T13], dTx[LL_2D][T13],
+    dTx[LU_2D][T13], dTx[UU_2D][T13]);
+  dTdx[UL_2D][T22] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T22], dTx[LL_2D][T22],
+    dTx[LU_2D][T22], dTx[UU_2D][T22]);
+  dTdx[UL_2D][T23] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T23], dTx[LL_2D][T23],
+    dTx[LU_2D][T23], dTx[UU_2D][T23]);
+  dTdx[UL_2D][T33] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T33], dTx[LL_2D][T33],
+    dTx[LU_2D][T33], dTx[UU_2D][T33]);
+
+  dTdx[UU_2D][T11] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T11], dTx[LL_2D][T11],
+    dTx[LU_2D][T11], dTx[UU_2D][T11]);
+  dTdx[UU_2D][T12] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T12], dTx[LL_2D][T12],
+    dTx[LU_2D][T12], dTx[UU_2D][T12]);
+  dTdx[UU_2D][T13] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T13], dTx[LL_2D][T13],
+    dTx[LU_2D][T13], dTx[UU_2D][T13]);
+  dTdx[UU_2D][T22] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T22], dTx[LL_2D][T22],
+    dTx[LU_2D][T22], dTx[UU_2D][T22]);
+  dTdx[UU_2D][T23] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T23], dTx[LL_2D][T23],
+    dTx[LU_2D][T23], dTx[UU_2D][T23]);
+  dTdx[UU_2D][T33] = calc_sym_grad_limiter_3D(limit, dTx[UL_2D][T33], dTx[LL_2D][T33],
+    dTx[LU_2D][T33], dTx[UU_2D][T33]);
+
+  dTy[LL_2D][T11] = calc_sym_grad_1D(dy, Tij[LLL_3D][T11], Tij[LUL_3D][T11]);
+  dTy[LL_2D][T12] = calc_sym_grad_1D(dy, Tij[LLL_3D][T12], Tij[LUL_3D][T12]);
+  dTy[LL_2D][T13] = calc_sym_grad_1D(dy, Tij[LLL_3D][T13], Tij[LUL_3D][T13]);
+  dTy[LL_2D][T22] = calc_sym_grad_1D(dy, Tij[LLL_3D][T22], Tij[LUL_3D][T22]);
+  dTy[LL_2D][T23] = calc_sym_grad_1D(dy, Tij[LLL_3D][T23], Tij[LUL_3D][T23]);
+  dTy[LL_2D][T33] = calc_sym_grad_1D(dy, Tij[LLL_3D][T33], Tij[LUL_3D][T33]);
+
+  dTy[LU_2D][T11] = calc_sym_grad_1D(dy, Tij[ULL_3D][T11], Tij[UUL_3D][T11]);
+  dTy[LU_2D][T12] = calc_sym_grad_1D(dy, Tij[ULL_3D][T12], Tij[UUL_3D][T12]);
+  dTy[LU_2D][T13] = calc_sym_grad_1D(dy, Tij[ULL_3D][T13], Tij[UUL_3D][T13]);
+  dTy[LU_2D][T22] = calc_sym_grad_1D(dy, Tij[ULL_3D][T22], Tij[UUL_3D][T22]);
+  dTy[LU_2D][T23] = calc_sym_grad_1D(dy, Tij[ULL_3D][T23], Tij[UUL_3D][T23]);
+  dTy[LU_2D][T33] = calc_sym_grad_1D(dy, Tij[ULL_3D][T33], Tij[UUL_3D][T33]);
+
+  dTy[UL_2D][T11] = calc_sym_grad_1D(dy, Tij[LLU_3D][T11], Tij[LUU_3D][T11]);
+  dTy[UL_2D][T12] = calc_sym_grad_1D(dy, Tij[LLU_3D][T12], Tij[LUU_3D][T12]);
+  dTy[UL_2D][T13] = calc_sym_grad_1D(dy, Tij[LLU_3D][T13], Tij[LUU_3D][T13]);
+  dTy[UL_2D][T22] = calc_sym_grad_1D(dy, Tij[LLU_3D][T22], Tij[LUU_3D][T22]);
+  dTy[UL_2D][T23] = calc_sym_grad_1D(dy, Tij[LLU_3D][T23], Tij[LUU_3D][T23]);
+  dTy[UL_2D][T33] = calc_sym_grad_1D(dy, Tij[LLU_3D][T33], Tij[LUU_3D][T33]);
+
+  dTy[UU_2D][T11] = calc_sym_grad_1D(dy, Tij[ULU_3D][T11], Tij[UUU_3D][T11]);
+  dTy[UU_2D][T12] = calc_sym_grad_1D(dy, Tij[ULU_3D][T12], Tij[UUU_3D][T12]);
+  dTy[UU_2D][T13] = calc_sym_grad_1D(dy, Tij[ULU_3D][T13], Tij[UUU_3D][T13]);
+  dTy[UU_2D][T22] = calc_sym_grad_1D(dy, Tij[ULU_3D][T22], Tij[UUU_3D][T22]);
+  dTy[UU_2D][T23] = calc_sym_grad_1D(dy, Tij[ULU_3D][T23], Tij[UUU_3D][T23]);
+  dTy[UU_2D][T33] = calc_sym_grad_1D(dy, Tij[ULU_3D][T33], Tij[UUU_3D][T33]);
+
+  dTdy[LL_2D][T11] = calc_sym_grad_limiter_3D(limit, dTy[LL_2D][T11], dTy[LU_2D][T11],
+    dTy[UL_2D][T11], dTy[UU_2D][T11]);
+  dTdy[LL_2D][T12] = calc_sym_grad_limiter_3D(limit, dTy[LL_2D][T12], dTy[LU_2D][T12],
+    dTy[UL_2D][T12], dTy[UU_2D][T12]);
+  dTdy[LL_2D][T13] = calc_sym_grad_limiter_3D(limit, dTy[LL_2D][T13], dTy[LU_2D][T13],
+    dTy[UL_2D][T13], dTy[UU_2D][T13]);
+  dTdy[LL_2D][T22] = calc_sym_grad_limiter_3D(limit, dTy[LL_2D][T22], dTy[LU_2D][T22],
+    dTy[UL_2D][T22], dTy[UU_2D][T22]);
+  dTdy[LL_2D][T23] = calc_sym_grad_limiter_3D(limit, dTy[LL_2D][T23], dTy[LU_2D][T23],
+    dTy[UL_2D][T23], dTy[UU_2D][T23]);
+  dTdy[LL_2D][T33] = calc_sym_grad_limiter_3D(limit, dTy[LL_2D][T33], dTy[LU_2D][T33],
+    dTy[UL_2D][T33], dTy[UU_2D][T33]);
+
+  dTdy[LU_2D][T11] = calc_sym_grad_limiter_3D(limit, dTy[LU_2D][T11], dTy[LL_2D][T11],
+    dTy[UL_2D][T11], dTy[UU_2D][T11]);
+  dTdy[LU_2D][T12] = calc_sym_grad_limiter_3D(limit, dTy[LU_2D][T12], dTy[LL_2D][T12],
+    dTy[UL_2D][T12], dTy[UU_2D][T12]);
+  dTdy[LU_2D][T13] = calc_sym_grad_limiter_3D(limit, dTy[LU_2D][T13], dTy[LL_2D][T13],
+    dTy[UL_2D][T13], dTy[UU_2D][T13]);
+  dTdy[LU_2D][T22] = calc_sym_grad_limiter_3D(limit, dTy[LU_2D][T22], dTy[LL_2D][T22],
+    dTy[UL_2D][T22], dTy[UU_2D][T22]);
+  dTdy[LU_2D][T23] = calc_sym_grad_limiter_3D(limit, dTy[LU_2D][T23], dTy[LL_2D][T23],
+    dTy[UL_2D][T23], dTy[UU_2D][T23]);
+  dTdy[LU_2D][T33] = calc_sym_grad_limiter_3D(limit, dTy[LU_2D][T33], dTy[LL_2D][T33],
+    dTy[UL_2D][T33], dTy[UU_2D][T33]);
+
+  dTdy[UL_2D][T11] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T11], dTy[LL_2D][T11],
+    dTy[LU_2D][T11], dTy[UU_2D][T11]);
+  dTdy[UL_2D][T12] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T12], dTy[LL_2D][T12],
+    dTy[LU_2D][T12], dTy[UU_2D][T12]);
+  dTdy[UL_2D][T13] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T13], dTy[LL_2D][T13],
+    dTy[LU_2D][T13], dTy[UU_2D][T13]);
+  dTdy[UL_2D][T22] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T22], dTy[LL_2D][T22],
+    dTy[LU_2D][T22], dTy[UU_2D][T22]);
+  dTdy[UL_2D][T23] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T23], dTy[LL_2D][T23],
+    dTy[LU_2D][T23], dTy[UU_2D][T23]);
+  dTdy[UL_2D][T33] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T33], dTy[LL_2D][T33],
+    dTy[LU_2D][T33], dTy[UU_2D][T33]);
+
+  dTdy[UU_2D][T11] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T11], dTy[LL_2D][T11],
+    dTy[LU_2D][T11], dTy[UU_2D][T11]);
+  dTdy[UU_2D][T12] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T12], dTy[LL_2D][T12],
+    dTy[LU_2D][T12], dTy[UU_2D][T12]);
+  dTdy[UU_2D][T13] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T13], dTy[LL_2D][T13],
+    dTy[LU_2D][T13], dTy[UU_2D][T13]);
+  dTdy[UU_2D][T22] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T22], dTy[LL_2D][T22],
+    dTy[LU_2D][T22], dTy[UU_2D][T22]);
+  dTdy[UU_2D][T23] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T23], dTy[LL_2D][T23],
+    dTy[LU_2D][T23], dTy[UU_2D][T23]);
+  dTdy[UU_2D][T33] = calc_sym_grad_limiter_3D(limit, dTy[UL_2D][T33], dTy[LL_2D][T33],
+    dTy[LU_2D][T33], dTy[UU_2D][T33]);
+
+  dTz[LL_2D][T11] = calc_sym_grad_1D(dz, Tij[LLL_3D][T11], Tij[LLU_3D][T11]);
+  dTz[LL_2D][T12] = calc_sym_grad_1D(dz, Tij[LLL_3D][T12], Tij[LLU_3D][T12]);
+  dTz[LL_2D][T13] = calc_sym_grad_1D(dz, Tij[LLL_3D][T13], Tij[LLU_3D][T13]);
+  dTz[LL_2D][T22] = calc_sym_grad_1D(dz, Tij[LLL_3D][T22], Tij[LLU_3D][T22]);
+  dTz[LL_2D][T23] = calc_sym_grad_1D(dz, Tij[LLL_3D][T23], Tij[LLU_3D][T23]);
+  dTz[LL_2D][T33] = calc_sym_grad_1D(dz, Tij[LLL_3D][T33], Tij[LLU_3D][T33]);
+
+  dTz[LU_2D][T11] = calc_sym_grad_1D(dz, Tij[ULL_3D][T11], Tij[ULU_3D][T11]);
+  dTz[LU_2D][T12] = calc_sym_grad_1D(dz, Tij[ULL_3D][T12], Tij[ULU_3D][T12]);
+  dTz[LU_2D][T13] = calc_sym_grad_1D(dz, Tij[ULL_3D][T13], Tij[ULU_3D][T13]);
+  dTz[LU_2D][T22] = calc_sym_grad_1D(dz, Tij[ULL_3D][T22], Tij[ULU_3D][T22]);
+  dTz[LU_2D][T23] = calc_sym_grad_1D(dz, Tij[ULL_3D][T23], Tij[ULU_3D][T23]);
+  dTz[LU_2D][T33] = calc_sym_grad_1D(dz, Tij[ULL_3D][T33], Tij[ULU_3D][T33]);
+
+  dTz[UL_2D][T11] = calc_sym_grad_1D(dz, Tij[LUL_3D][T11], Tij[LUU_3D][T11]);
+  dTz[UL_2D][T12] = calc_sym_grad_1D(dz, Tij[LUL_3D][T12], Tij[LUU_3D][T12]);
+  dTz[UL_2D][T13] = calc_sym_grad_1D(dz, Tij[LUL_3D][T13], Tij[LUU_3D][T13]);
+  dTz[UL_2D][T22] = calc_sym_grad_1D(dz, Tij[LUL_3D][T22], Tij[LUU_3D][T22]);
+  dTz[UL_2D][T23] = calc_sym_grad_1D(dz, Tij[LUL_3D][T23], Tij[LUU_3D][T23]);
+  dTz[UL_2D][T33] = calc_sym_grad_1D(dz, Tij[LUL_3D][T33], Tij[LUU_3D][T33]);
+
+  dTz[UU_2D][T11] = calc_sym_grad_1D(dz, Tij[UUL_3D][T11], Tij[UUU_3D][T11]);
+  dTz[UU_2D][T12] = calc_sym_grad_1D(dz, Tij[UUL_3D][T12], Tij[UUU_3D][T12]);
+  dTz[UU_2D][T13] = calc_sym_grad_1D(dz, Tij[UUL_3D][T13], Tij[UUU_3D][T13]);
+  dTz[UU_2D][T22] = calc_sym_grad_1D(dz, Tij[UUL_3D][T22], Tij[UUU_3D][T22]);
+  dTz[UU_2D][T23] = calc_sym_grad_1D(dz, Tij[UUL_3D][T23], Tij[UUU_3D][T23]);
+  dTz[UU_2D][T33] = calc_sym_grad_1D(dz, Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
+
+  dTdz[LL_2D][T11] = calc_sym_grad_limiter_3D(limit, dTz[LL_2D][T11], dTz[LU_2D][T11],
+    dTz[UL_2D][T11], dTz[UU_2D][T11]);
+  dTdz[LL_2D][T12] = calc_sym_grad_limiter_3D(limit, dTz[LL_2D][T12], dTz[LU_2D][T12],
+    dTz[UL_2D][T12], dTz[UU_2D][T12]);
+  dTdz[LL_2D][T13] = calc_sym_grad_limiter_3D(limit, dTz[LL_2D][T13], dTz[LU_2D][T13],
+    dTz[UL_2D][T13], dTz[UU_2D][T13]);
+  dTdz[LL_2D][T22] = calc_sym_grad_limiter_3D(limit, dTz[LL_2D][T22], dTz[LU_2D][T22],
+    dTz[UL_2D][T22], dTz[UU_2D][T22]);
+  dTdz[LL_2D][T23] = calc_sym_grad_limiter_3D(limit, dTz[LL_2D][T23], dTz[LU_2D][T23],
+    dTz[UL_2D][T23], dTz[UU_2D][T23]);
+  dTdz[LL_2D][T33] = calc_sym_grad_limiter_3D(limit, dTz[LL_2D][T33], dTz[LU_2D][T33],
+    dTz[UL_2D][T33], dTz[UU_2D][T33]);
+
+  dTdz[LU_2D][T11] = calc_sym_grad_limiter_3D(limit, dTz[LU_2D][T11], dTz[LL_2D][T11],
+    dTz[UL_2D][T11], dTz[UU_2D][T11]);
+  dTdz[LU_2D][T12] = calc_sym_grad_limiter_3D(limit, dTz[LU_2D][T12], dTz[LL_2D][T12],
+    dTz[UL_2D][T12], dTz[UU_2D][T12]);
+  dTdz[LU_2D][T13] = calc_sym_grad_limiter_3D(limit, dTz[LU_2D][T13], dTz[LL_2D][T13],
+    dTz[UL_2D][T13], dTz[UU_2D][T13]);
+  dTdz[LU_2D][T22] = calc_sym_grad_limiter_3D(limit, dTz[LU_2D][T22], dTz[LL_2D][T22],
+    dTz[UL_2D][T22], dTz[UU_2D][T22]);
+  dTdz[LU_2D][T23] = calc_sym_grad_limiter_3D(limit, dTz[LU_2D][T23], dTz[LL_2D][T23],
+    dTz[UL_2D][T23], dTz[UU_2D][T23]);
+  dTdz[LU_2D][T33] = calc_sym_grad_limiter_3D(limit, dTz[LU_2D][T33], dTz[LL_2D][T33],
+    dTz[UL_2D][T33], dTz[UU_2D][T33]);
+
+  dTdz[UL_2D][T11] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T11], dTz[LL_2D][T11],
+    dTz[LU_2D][T11], dTz[UU_2D][T11]);
+  dTdz[UL_2D][T12] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T12], dTz[LL_2D][T12],
+    dTz[LU_2D][T12], dTz[UU_2D][T12]);
+  dTdz[UL_2D][T13] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T13], dTz[LL_2D][T13],
+    dTz[LU_2D][T13], dTz[UU_2D][T13]);
+  dTdz[UL_2D][T22] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T22], dTz[LL_2D][T22],
+    dTz[LU_2D][T22], dTz[UU_2D][T22]);
+  dTdz[UL_2D][T23] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T23], dTz[LL_2D][T23],
+    dTz[LU_2D][T23], dTz[UU_2D][T23]);
+  dTdz[UL_2D][T33] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T33], dTz[LL_2D][T33],
+    dTz[LU_2D][T33], dTz[UU_2D][T33]);
+
+  dTdz[UU_2D][T11] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T11], dTz[LL_2D][T11],
+    dTz[LU_2D][T11], dTz[UU_2D][T11]);
+  dTdz[UU_2D][T12] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T12], dTz[LL_2D][T12],
+    dTz[LU_2D][T12], dTz[UU_2D][T12]);
+  dTdz[UU_2D][T13] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T13], dTz[LL_2D][T13],
+    dTz[LU_2D][T13], dTz[UU_2D][T13]);
+  dTdz[UU_2D][T22] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T22], dTz[LL_2D][T22],
+    dTz[LU_2D][T22], dTz[UU_2D][T22]);
+  dTdz[UU_2D][T23] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T23], dTz[LL_2D][T23],
+    dTz[LU_2D][T23], dTz[UU_2D][T23]);
+  dTdz[UU_2D][T33] = calc_sym_grad_limiter_3D(limit, dTz[UL_2D][T33], dTz[LL_2D][T33],
+    dTz[LU_2D][T33], dTz[UU_2D][T33]);
+  
+  double alpha = 1.0/gces->k0;
+  double vth_avg = sqrt(p_avg/rho_avg);
+
+  // Temperature is actually T/m due to the formulation of var_setup.
+  // Thus, the mass density rho is used instead of number density n.
+  double chi = alpha*vth_avg*rho_avg;
+
+  int compx[8] = { LL_2D, UL_2D, LU_2D, UU_2D, LL_2D, UL_2D, LU_2D, UU_2D };
+  int compy[8] = { LL_2D, UL_2D, LL_2D, UL_2D, LU_2D, UU_2D, LU_2D, UU_2D };
+  int compz[8] = { LL_2D, LL_2D, UL_2D, UL_2D, LU_2D, LU_2D, UU_2D, UU_2D };
+
+  int signx[8] = { 1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0 };
+  int signy[8] = { 1.0, 1.0, -1.0, -1.0, 1.0, 1.0, -1.0, -1.0 };
+  int signz[8] = { 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0 };
+
+
+  q[LLL_3D][Q111] = chi*dTdx[compx[LLL_3D]][T11];
+  q[LLL_3D][Q112] = chi*(2.0*dTdx[compx[LLL_3D]][T12]
+    + dTdy[compy[LLL_3D]][T11])/3.0;
+  q[LLL_3D][Q113] = chi*(2.0*dTdx[compx[LLL_3D]][T13]
+    + dTdz[compz[LLL_3D]][T11])/3.0;
+  q[LLL_3D][Q122] = chi*(dTdx[compx[LLL_3D]][T22]
+    + 2.0*dTdy[compy[LLL_3D]][T12])/3.0;
+  q[LLL_3D][Q123] = chi*(dTdx[compx[LLL_3D]][T23]
+    + dTdy[compy[LLL_3D]][T13] + dTdz[compz[LLL_3D]][T12])/3.0;
+  q[LLL_3D][Q133] = chi*(dTdx[compx[LLL_3D]][T33]
+    + 2.0*dTdz[compz[LLL_3D]][T13])/3.0;
+  q[LLL_3D][Q222] = chi*dTdy[compy[LLL_3D]][T22];
+  q[LLL_3D][Q223] = chi*(2.0*dTdy[compy[LLL_3D]][T23]
+    + dTdz[compz[LLL_3D]][T22])/3.0;
+  q[LLL_3D][Q233] = chi*(dTdy[compy[LLL_3D]][T33]
+    + 2.0*dTdz[compz[LLL_3D]][T23])/3.0;
+  q[LLL_3D][Q333] = chi*dTdz[compz[LLL_3D]][T33];
+
+  q[LLU_3D][Q111] = chi*dTdx[compx[LLU_3D]][T11];
+  q[LLU_3D][Q112] = chi*(2.0*dTdx[compx[LLU_3D]][T12]
+    + dTdy[compy[LLU_3D]][T11])/3.0;
+  q[LLU_3D][Q113] = chi*(2.0*dTdx[compx[LLU_3D]][T13]
+    + dTdz[compz[LLU_3D]][T11])/3.0;
+  q[LLU_3D][Q122] = chi*(dTdx[compx[LLU_3D]][T22]
+    + 2.0*dTdy[compy[LLU_3D]][T12])/3.0;
+  q[LLU_3D][Q123] = chi*(dTdx[compx[LLU_3D]][T23]
+    + dTdy[compy[LLU_3D]][T13] + dTdz[compz[LLU_3D]][T12])/3.0;
+  q[LLU_3D][Q133] = chi*(dTdx[compx[LLU_3D]][T33]
+    + 2.0*dTdz[compz[LLU_3D]][T13])/3.0;
+  q[LLU_3D][Q222] = chi*dTdy[compy[LLU_3D]][T22];
+  q[LLU_3D][Q223] = chi*(2.0*dTdy[compy[LLU_3D]][T23]
+    + dTdz[compz[LLU_3D]][T22])/3.0;
+  q[LLU_3D][Q233] = chi*(dTdy[compy[LLU_3D]][T33]
+    + 2.0*dTdz[compz[LLU_3D]][T23])/3.0;
+  q[LLU_3D][Q333] = chi*dTdz[compz[LLU_3D]][T33];
+
+ q[LUL_3D][Q111] = chi*dTdx[compx[LUL_3D]][T11];
+  q[LUL_3D][Q112] = chi*(2.0*dTdx[compx[LUL_3D]][T12]
+    + dTdy[compy[LUL_3D]][T11])/3.0;
+  q[LUL_3D][Q113] = chi*(2.0*dTdx[compx[LUL_3D]][T13]
+    + dTdz[compz[LUL_3D]][T11])/3.0;
+  q[LUL_3D][Q122] = chi*(dTdx[compx[LUL_3D]][T22]
+    + 2.0*dTdy[compy[LUL_3D]][T12])/3.0;
+  q[LUL_3D][Q123] = chi*(dTdx[compx[LUL_3D]][T23]
+    + dTdy[compy[LUL_3D]][T13] + dTdz[compz[LUL_3D]][T12])/3.0;
+  q[LUL_3D][Q133] = chi*(dTdx[compx[LUL_3D]][T33]
+    + 2.0*dTdz[compz[LUL_3D]][T13])/3.0;
+  q[LUL_3D][Q222] = chi*dTdy[compy[LUL_3D]][T22];
+  q[LUL_3D][Q223] = chi*(2.0*dTdy[compy[LUL_3D]][T23]
+    + dTdz[compz[LUL_3D]][T22])/3.0;
+  q[LUL_3D][Q233] = chi*(dTdy[compy[LUL_3D]][T33]
+    + 2.0*dTdz[compz[LUL_3D]][T23])/3.0;
+  q[LUL_3D][Q333] = chi*dTdz[compz[LUL_3D]][T33];
+
+ q[LUU_3D][Q111] = chi*dTdx[compx[LUU_3D]][T11];
+  q[LUU_3D][Q112] = chi*(2.0*dTdx[compx[LUU_3D]][T12]
+    + dTdy[compy[LUU_3D]][T11])/3.0;
+  q[LUU_3D][Q113] = chi*(2.0*dTdx[compx[LUU_3D]][T13]
+    + dTdz[compz[LUU_3D]][T11])/3.0;
+  q[LUU_3D][Q122] = chi*(dTdx[compx[LUU_3D]][T22]
+    + 2.0*dTdy[compy[LUU_3D]][T12])/3.0;
+  q[LUU_3D][Q123] = chi*(dTdx[compx[LUU_3D]][T23]
+    + dTdy[compy[LUU_3D]][T13] + dTdz[compz[LUU_3D]][T12])/3.0;
+  q[LUU_3D][Q133] = chi*(dTdx[compx[LUU_3D]][T33]
+    + 2.0*dTdz[compz[LUU_3D]][T13])/3.0;
+  q[LUU_3D][Q222] = chi*dTdy[compy[LUU_3D]][T22];
+  q[LUU_3D][Q223] = chi*(2.0*dTdy[compy[LUU_3D]][T23]
+    + dTdz[compz[LUU_3D]][T22])/3.0;
+  q[LUU_3D][Q233] = chi*(dTdy[compy[LUU_3D]][T33]
+    + 2.0*dTdz[compz[LUU_3D]][T23])/3.0;
+  q[LUU_3D][Q333] = chi*dTdz[compz[LUU_3D]][T33];
+
+ q[ULL_3D][Q111] = chi*dTdx[compx[ULL_3D]][T11];
+  q[ULL_3D][Q112] = chi*(2.0*dTdx[compx[ULL_3D]][T12]
+    + dTdy[compy[ULL_3D]][T11])/3.0;
+  q[ULL_3D][Q113] = chi*(2.0*dTdx[compx[ULL_3D]][T13]
+    + dTdz[compz[ULL_3D]][T11])/3.0;
+  q[ULL_3D][Q122] = chi*(dTdx[compx[ULL_3D]][T22]
+    + 2.0*dTdy[compy[ULL_3D]][T12])/3.0;
+  q[ULL_3D][Q123] = chi*(dTdx[compx[ULL_3D]][T23]
+    + dTdy[compy[ULL_3D]][T13] + dTdz[compz[ULL_3D]][T12])/3.0;
+  q[ULL_3D][Q133] = chi*(dTdx[compx[ULL_3D]][T33]
+    + 2.0*dTdz[compz[ULL_3D]][T13])/3.0;
+  q[ULL_3D][Q222] = chi*dTdy[compy[ULL_3D]][T22];
+  q[ULL_3D][Q223] = chi*(2.0*dTdy[compy[ULL_3D]][T23]
+    + dTdz[compz[ULL_3D]][T22])/3.0;
+  q[ULL_3D][Q233] = chi*(dTdy[compy[ULL_3D]][T33]
+    + 2.0*dTdz[compz[ULL_3D]][T23])/3.0;
+  q[ULL_3D][Q333] = chi*dTdz[compz[ULL_3D]][T33];
+
+  q[ULU_3D][Q111] = chi*dTdx[compx[ULU_3D]][T11];
+  q[ULU_3D][Q112] = chi*(2.0*dTdx[compx[ULU_3D]][T12]
+    + dTdy[compy[ULU_3D]][T11])/3.0;
+  q[ULU_3D][Q113] = chi*(2.0*dTdx[compx[ULU_3D]][T13]
+    + dTdz[compz[ULU_3D]][T11])/3.0;
+  q[ULU_3D][Q122] = chi*(dTdx[compx[ULU_3D]][T22]
+    + 2.0*dTdy[compy[ULU_3D]][T12])/3.0;
+  q[ULU_3D][Q123] = chi*(dTdx[compx[ULU_3D]][T23]
+    + dTdy[compy[ULU_3D]][T13] + dTdz[compz[ULU_3D]][T12])/3.0;
+  q[ULU_3D][Q133] = chi*(dTdx[compx[ULU_3D]][T33]
+    + 2.0*dTdz[compz[ULU_3D]][T13])/3.0;
+  q[ULU_3D][Q222] = chi*dTdy[compy[ULU_3D]][T22];
+  q[ULU_3D][Q223] = chi*(2.0*dTdy[compy[ULU_3D]][T23]
+    + dTdz[compz[ULU_3D]][T22])/3.0;
+  q[ULU_3D][Q233] = chi*(dTdy[compy[ULU_3D]][T33]
+    + 2.0*dTdz[compz[ULU_3D]][T23])/3.0;
+  q[ULU_3D][Q333] = chi*dTdz[compz[ULU_3D]][T33];
+
+  q[UUL_3D][Q111] = chi*dTdx[compx[UUL_3D]][T11];
+  q[UUL_3D][Q112] = chi*(2.0*dTdx[compx[UUL_3D]][T12]
+    + dTdy[compy[UUL_3D]][T11])/3.0;
+  q[UUL_3D][Q113] = chi*(2.0*dTdx[compx[UUL_3D]][T13]
+    + dTdz[compz[UUL_3D]][T11])/3.0;
+  q[UUL_3D][Q122] = chi*(dTdx[compx[UUL_3D]][T22]
+    + 2.0*dTdy[compy[UUL_3D]][T12])/3.0;
+  q[UUL_3D][Q123] = chi*(dTdx[compx[UUL_3D]][T23]
+    + dTdy[compy[UUL_3D]][T13] + dTdz[compz[UUL_3D]][T12])/3.0;
+  q[UUL_3D][Q133] = chi*(dTdx[compx[UUL_3D]][T33]
+    + 2.0*dTdz[compz[UUL_3D]][T13])/3.0;
+  q[UUL_3D][Q222] = chi*dTdy[compy[UUL_3D]][T22];
+  q[UUL_3D][Q223] = chi*(2.0*dTdy[compy[UUL_3D]][T23]
+    + dTdz[compz[UUL_3D]][T22])/3.0;
+  q[UUL_3D][Q233] = chi*(dTdy[compy[UUL_3D]][T33]
+    + 2.0*dTdz[compz[UUL_3D]][T23])/3.0;
+  q[UUL_3D][Q333] = chi*dTdz[compz[UUL_3D]][T33];
+
+  q[UUU_3D][Q111] = chi*dTdx[compx[UUU_3D]][T11];
+  q[UUU_3D][Q112] = chi*(2.0*dTdx[compx[UUU_3D]][T12]
+    + dTdy[compy[UUU_3D]][T11])/3.0;
+  q[UUU_3D][Q113] = chi*(2.0*dTdx[compx[UUU_3D]][T13]
+    + dTdz[compz[UUU_3D]][T11])/3.0;
+  q[UUU_3D][Q122] = chi*(dTdx[compx[UUU_3D]][T22]
+    + 2.0*dTdy[compy[UUU_3D]][T12])/3.0;
+  q[UUU_3D][Q123] = chi*(dTdx[compx[UUU_3D]][T23]
+    + dTdy[compy[UUU_3D]][T13] + dTdz[compz[UUU_3D]][T12])/3.0;
+  q[UUU_3D][Q133] = chi*(dTdx[compx[UUU_3D]][T33]
+    + 2.0*dTdz[compz[UUU_3D]][T13])/3.0;
+  q[UUU_3D][Q222] = chi*dTdy[compy[UUU_3D]][T22];
+  q[UUU_3D][Q223] = chi*(2.0*dTdy[compy[UUU_3D]][T23]
+    + dTdz[compz[UUU_3D]][T22])/3.0;
+  q[UUU_3D][Q233] = chi*(dTdy[compy[UUU_3D]][T33]
+    + 2.0*dTdz[compz[UUU_3D]][T23])/3.0;
+  q[UUU_3D][Q333] = chi*dTdz[compz[UUU_3D]][T33];
+
+  rhs_d[LLL_3D][P11] += signx[LLL_3D]*q[LLL_3D][Q111]/(4.0*dx)
+    + signy[LLL_3D]*q[LLL_3D][Q112]/(4.0*dy)
+    + signz[LLL_3D]*q[LLL_3D][Q113]/(4.0*dz);
+  rhs_d[LLL_3D][P12] += signx[LLL_3D]*q[LLL_3D][Q112]/(4.0*dx)
+    + signy[LLL_3D]*q[LLL_3D][Q122]/(4.0*dy)
+    + signz[LLL_3D]*q[LLL_3D][Q123]/(4.0*dz);
+  rhs_d[LLL_3D][P13] += signx[LLL_3D]*q[LLL_3D][Q113]/(4.0*dx)
+    + signy[LLL_3D]*q[LLL_3D][Q123]/(4.0*dy)
+    + signz[LLL_3D]*q[LLL_3D][Q133]/(4.0*dz);
+  rhs_d[LLL_3D][P22] += signx[LLL_3D]*q[LLL_3D][Q122]/(4.0*dx)
+    + signy[LLL_3D]*q[LLL_3D][Q222]/(4.0*dy)
+    + signz[LLL_3D]*q[LLL_3D][Q223]/(4.0*dz);
+  rhs_d[LLL_3D][P23] += signx[LLL_3D]*q[LLL_3D][Q123]/(4.0*dx) 
+    + signy[LLL_3D]*q[LLL_3D][Q223]/(4.0*dy)
+    + signz[LLL_3D]*q[LLL_3D][Q233]/(4.0*dz);
+  rhs_d[LLL_3D][P33] += signx[LLL_3D]*q[LLL_3D][Q133]/(4.0*dx)
+    + signy[LLL_3D]*q[LLL_3D][Q233]/(4.0*dy)
+    + signz[LLL_3D]*q[LLL_3D][Q333]/(4.0*dz);
+
+  rhs_d[LLU_3D][P11] += signx[LLU_3D]*q[LLU_3D][Q111]/(4.0*dx)
+    + signy[LLU_3D]*q[LLU_3D][Q112]/(4.0*dy)
+    + signz[LLU_3D]*q[LLU_3D][Q113]/(4.0*dz);
+  rhs_d[LLU_3D][P12] += signx[LLU_3D]*q[LLU_3D][Q112]/(4.0*dx)
+    + signy[LLU_3D]*q[LLU_3D][Q122]/(4.0*dy)
+    + signz[LLU_3D]*q[LLU_3D][Q123]/(4.0*dz);
+  rhs_d[LLU_3D][P13] += signx[LLU_3D]*q[LLU_3D][Q113]/(4.0*dx)
+    + signy[LLU_3D]*q[LLU_3D][Q123]/(4.0*dy)
+    + signz[LLU_3D]*q[LLU_3D][Q133]/(4.0*dz);
+  rhs_d[LLU_3D][P22] += signx[LLU_3D]*q[LLU_3D][Q122]/(4.0*dx)
+    + signy[LLU_3D]*q[LLU_3D][Q222]/(4.0*dy)
+    + signz[LLU_3D]*q[LLU_3D][Q223]/(4.0*dz);
+  rhs_d[LLU_3D][P23] += signx[LLU_3D]*q[LLU_3D][Q123]/(4.0*dx) 
+    + signy[LLU_3D]*q[LLU_3D][Q223]/(4.0*dy)
+    + signz[LLU_3D]*q[LLU_3D][Q233]/(4.0*dz);
+  rhs_d[LLU_3D][P33] += signx[LLU_3D]*q[LLU_3D][Q133]/(4.0*dx)
+    + signy[LLU_3D]*q[LLU_3D][Q233]/(4.0*dy)
+    + signz[LLU_3D]*q[LLU_3D][Q333]/(4.0*dz);
+
+  rhs_d[LUL_3D][P11] += signx[LUL_3D]*q[LUL_3D][Q111]/(4.0*dx)
+    + signy[LUL_3D]*q[LUL_3D][Q112]/(4.0*dy)
+    + signz[LUL_3D]*q[LUL_3D][Q113]/(4.0*dz);
+  rhs_d[LUL_3D][P12] += signx[LUL_3D]*q[LUL_3D][Q112]/(4.0*dx)
+    + signy[LUL_3D]*q[LUL_3D][Q122]/(4.0*dy)
+    + signz[LUL_3D]*q[LUL_3D][Q123]/(4.0*dz);
+  rhs_d[LUL_3D][P13] += signx[LUL_3D]*q[LUL_3D][Q113]/(4.0*dx)
+    + signy[LUL_3D]*q[LUL_3D][Q123]/(4.0*dy)
+    + signz[LUL_3D]*q[LUL_3D][Q133]/(4.0*dz);
+  rhs_d[LUL_3D][P22] += signx[LUL_3D]*q[LUL_3D][Q122]/(4.0*dx)
+    + signy[LUL_3D]*q[LUL_3D][Q222]/(4.0*dy)
+    + signz[LUL_3D]*q[LUL_3D][Q223]/(4.0*dz);
+  rhs_d[LUL_3D][P23] += signx[LUL_3D]*q[LUL_3D][Q123]/(4.0*dx) 
+    + signy[LUL_3D]*q[LUL_3D][Q223]/(4.0*dy)
+    + signz[LUL_3D]*q[LUL_3D][Q233]/(4.0*dz);
+  rhs_d[LUL_3D][P33] += signx[LUL_3D]*q[LUL_3D][Q133]/(4.0*dx)
+    + signy[LUL_3D]*q[LUL_3D][Q233]/(4.0*dy)
+    + signz[LUL_3D]*q[LUL_3D][Q333]/(4.0*dz);
+
+  rhs_d[LUU_3D][P11] += signx[LUU_3D]*q[LUU_3D][Q111]/(4.0*dx)
+    + signy[LUU_3D]*q[LUU_3D][Q112]/(4.0*dy)
+    + signz[LUU_3D]*q[LUU_3D][Q113]/(4.0*dz);
+  rhs_d[LUU_3D][P12] += signx[LUU_3D]*q[LUU_3D][Q112]/(4.0*dx)
+    + signy[LUU_3D]*q[LUU_3D][Q122]/(4.0*dy)
+    + signz[LUU_3D]*q[LUU_3D][Q123]/(4.0*dz);
+  rhs_d[LUU_3D][P13] += signx[LUU_3D]*q[LUU_3D][Q113]/(4.0*dx)
+    + signy[LUU_3D]*q[LUU_3D][Q123]/(4.0*dy)
+    + signz[LUU_3D]*q[LUU_3D][Q133]/(4.0*dz);
+  rhs_d[LUU_3D][P22] += signx[LUU_3D]*q[LUU_3D][Q122]/(4.0*dx)
+    + signy[LUU_3D]*q[LUU_3D][Q222]/(4.0*dy)
+    + signz[LUU_3D]*q[LUU_3D][Q223]/(4.0*dz);
+  rhs_d[LUU_3D][P23] += signx[LUU_3D]*q[LUU_3D][Q123]/(4.0*dx) 
+    + signy[LUU_3D]*q[LUU_3D][Q223]/(4.0*dy)
+    + signz[LUU_3D]*q[LUU_3D][Q233]/(4.0*dz);
+  rhs_d[LUU_3D][P33] += signx[LUU_3D]*q[LUU_3D][Q133]/(4.0*dx)
+    + signy[LUU_3D]*q[LUU_3D][Q233]/(4.0*dy)
+    + signz[LUU_3D]*q[LUU_3D][Q333]/(4.0*dz);
+
+  rhs_d[ULL_3D][P11] += signx[ULL_3D]*q[ULL_3D][Q111]/(4.0*dx)
+    + signy[ULL_3D]*q[ULL_3D][Q112]/(4.0*dy)
+    + signz[ULL_3D]*q[ULL_3D][Q113]/(4.0*dz);
+  rhs_d[ULL_3D][P12] += signx[ULL_3D]*q[ULL_3D][Q112]/(4.0*dx)
+    + signy[ULL_3D]*q[ULL_3D][Q122]/(4.0*dy)
+    + signz[ULL_3D]*q[ULL_3D][Q123]/(4.0*dz);
+  rhs_d[ULL_3D][P13] += signx[ULL_3D]*q[ULL_3D][Q113]/(4.0*dx)
+    + signy[ULL_3D]*q[ULL_3D][Q123]/(4.0*dy)
+    + signz[ULL_3D]*q[ULL_3D][Q133]/(4.0*dz);
+  rhs_d[ULL_3D][P22] += signx[ULL_3D]*q[ULL_3D][Q122]/(4.0*dx)
+    + signy[ULL_3D]*q[ULL_3D][Q222]/(4.0*dy)
+    + signz[ULL_3D]*q[ULL_3D][Q223]/(4.0*dz);
+  rhs_d[ULL_3D][P23] += signx[ULL_3D]*q[ULL_3D][Q123]/(4.0*dx) 
+    + signy[ULL_3D]*q[ULL_3D][Q223]/(4.0*dy)
+    + signz[ULL_3D]*q[ULL_3D][Q233]/(4.0*dz);
+  rhs_d[ULL_3D][P33] += signx[ULL_3D]*q[ULL_3D][Q133]/(4.0*dx)
+    + signy[ULL_3D]*q[ULL_3D][Q233]/(4.0*dy)
+    + signz[ULL_3D]*q[ULL_3D][Q333]/(4.0*dz);
+
+  rhs_d[ULU_3D][P11] += signx[ULU_3D]*q[ULU_3D][Q111]/(4.0*dx)
+    + signy[ULU_3D]*q[ULU_3D][Q112]/(4.0*dy)
+    + signz[ULU_3D]*q[ULU_3D][Q113]/(4.0*dz);
+  rhs_d[ULU_3D][P12] += signx[ULU_3D]*q[ULU_3D][Q112]/(4.0*dx)
+    + signy[ULU_3D]*q[ULU_3D][Q122]/(4.0*dy)
+    + signz[ULU_3D]*q[ULU_3D][Q123]/(4.0*dz);
+  rhs_d[ULU_3D][P13] += signx[ULU_3D]*q[ULU_3D][Q113]/(4.0*dx)
+    + signy[ULU_3D]*q[ULU_3D][Q123]/(4.0*dy)
+    + signz[ULU_3D]*q[ULU_3D][Q133]/(4.0*dz);
+  rhs_d[ULU_3D][P22] += signx[ULU_3D]*q[ULU_3D][Q122]/(4.0*dx)
+    + signy[ULU_3D]*q[ULU_3D][Q222]/(4.0*dy)
+    + signz[ULU_3D]*q[ULU_3D][Q223]/(4.0*dz);
+  rhs_d[ULU_3D][P23] += signx[ULU_3D]*q[ULU_3D][Q123]/(4.0*dx) 
+    + signy[ULU_3D]*q[ULU_3D][Q223]/(4.0*dy)
+    + signz[ULU_3D]*q[ULU_3D][Q233]/(4.0*dz);
+  rhs_d[ULU_3D][P33] += signx[ULU_3D]*q[ULU_3D][Q133]/(4.0*dx)
+    + signy[ULU_3D]*q[ULU_3D][Q233]/(4.0*dy)
+    + signz[ULU_3D]*q[ULU_3D][Q333]/(4.0*dz);
+
+  rhs_d[UUL_3D][P11] += signx[UUL_3D]*q[UUL_3D][Q111]/(4.0*dx)
+    + signy[UUL_3D]*q[UUL_3D][Q112]/(4.0*dy)
+    + signz[UUL_3D]*q[UUL_3D][Q113]/(4.0*dz);
+  rhs_d[UUL_3D][P12] += signx[UUL_3D]*q[UUL_3D][Q112]/(4.0*dx)
+    + signy[UUL_3D]*q[UUL_3D][Q122]/(4.0*dy)
+    + signz[UUL_3D]*q[UUL_3D][Q123]/(4.0*dz);
+  rhs_d[UUL_3D][P13] += signx[UUL_3D]*q[UUL_3D][Q113]/(4.0*dx)
+    + signy[UUL_3D]*q[UUL_3D][Q123]/(4.0*dy)
+    + signz[UUL_3D]*q[UUL_3D][Q133]/(4.0*dz);
+  rhs_d[UUL_3D][P22] += signx[UUL_3D]*q[UUL_3D][Q122]/(4.0*dx)
+    + signy[UUL_3D]*q[UUL_3D][Q222]/(4.0*dy)
+    + signz[UUL_3D]*q[UUL_3D][Q223]/(4.0*dz);
+  rhs_d[UUL_3D][P23] += signx[UUL_3D]*q[UUL_3D][Q123]/(4.0*dx) 
+    + signy[UUL_3D]*q[UUL_3D][Q223]/(4.0*dy)
+    + signz[UUL_3D]*q[UUL_3D][Q233]/(4.0*dz);
+  rhs_d[UUL_3D][P33] += signx[UUL_3D]*q[UUL_3D][Q133]/(4.0*dx)
+    + signy[UUL_3D]*q[UUL_3D][Q233]/(4.0*dy)
+    + signz[UUL_3D]*q[UUL_3D][Q333]/(4.0*dz);
+
+  rhs_d[UUU_3D][P11] += signx[UUU_3D]*q[UUU_3D][Q111]/(4.0*dx)
+    + signy[UUU_3D]*q[UUU_3D][Q112]/(4.0*dy)
+    + signz[UUU_3D]*q[UUU_3D][Q113]/(4.0*dz);
+  rhs_d[UUU_3D][P12] += signx[UUU_3D]*q[UUU_3D][Q112]/(4.0*dx)
+    + signy[UUU_3D]*q[UUU_3D][Q122]/(4.0*dy)
+    + signz[UUU_3D]*q[UUU_3D][Q123]/(4.0*dz);
+  rhs_d[UUU_3D][P13] += signx[UUU_3D]*q[UUU_3D][Q113]/(4.0*dx)
+    + signy[UUU_3D]*q[UUU_3D][Q123]/(4.0*dy)
+    + signz[UUU_3D]*q[UUU_3D][Q133]/(4.0*dz);
+  rhs_d[UUU_3D][P22] += signx[UUU_3D]*q[UUU_3D][Q122]/(4.0*dx)
+    + signy[UUU_3D]*q[UUU_3D][Q222]/(4.0*dy)
+    + signz[UUU_3D]*q[UUU_3D][Q223]/(4.0*dz);
+  rhs_d[UUU_3D][P23] += signx[UUU_3D]*q[UUU_3D][Q123]/(4.0*dx) 
+    + signy[UUU_3D]*q[UUU_3D][Q223]/(4.0*dy)
+    + signz[UUU_3D]*q[UUU_3D][Q233]/(4.0*dz);
+  rhs_d[UUU_3D][P33] += signx[UUU_3D]*q[UUU_3D][Q133]/(4.0*dx)
+    + signy[UUU_3D]*q[UUU_3D][Q233]/(4.0*dy)
+    + signz[UUU_3D]*q[UUU_3D][Q333]/(4.0*dz);
+
+  double da = fmin(fmin(dx, dy), dz);
+  double cfla = dt/(da*da);
+  return fmax(alpha*vth_avg*cfla, cfl);
+}
+
+static const heat_flux_calc_t grad_closure_unmag_funcs[3] = { calc_unmag_heat_flux_1d,
+  calc_unmag_heat_flux_2d, calc_unmag_heat_flux_3d };
+
+void
+grad_closure_calc_q_choose(struct gkyl_ten_moment_grad_closure *gces)
+{
+  gces->calc_q = grad_closure_unmag_funcs[gces->ndim - 1];
+}

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -17,6 +17,8 @@ struct gkyl_ten_moment_grad_closure {
 
   heat_flux_calc_t calc_q;
   heat_flux_update_t update_q;
+
+  struct gkyl_ten_moment_grad_closure *on_dev;
 };
 
 // Makes indexing cleaner
@@ -57,6 +59,7 @@ enum loc_3d {
   UUL_3D, UUU_3D
 };
 
+GKYL_CU_D
 static void
 var_setup(const gkyl_ten_moment_grad_closure *gces,
   int start, int end,
@@ -77,6 +80,7 @@ var_setup(const gkyl_ten_moment_grad_closure *gces,
   }
 }
 
+GKYL_CU_D
 static inline double
 calc_sym_grad_limiter_2D(double alpha, double a, double b)
 {
@@ -92,6 +96,7 @@ calc_sym_grad_limiter_2D(double alpha, double a, double b)
   }
 }
 
+GKYL_CU_D
 static inline double
 calc_sym_grad_limiter_3D(double alpha, double a, double b, double c, double d)
 {
@@ -107,7 +112,8 @@ calc_sym_grad_limiter_3D(double alpha, double a, double b, double c, double d)
   }
 }
 
-void
+GKYL_CU_D
+static void
 calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
   const double *fluid_d[], double *cflrate, double dt, double *q)
 {
@@ -152,7 +158,8 @@ calc_unmag_heat_flux_1d(const gkyl_ten_moment_grad_closure *gces,
   cflrate[0] = alpha*vth_avg*cfla;
 }
 
-void
+GKYL_CU_D
+static void
 grad_closure_update_1d(const gkyl_ten_moment_grad_closure *gces,
   const double *q[], double *rhs)
 {
@@ -179,7 +186,8 @@ grad_closure_update_1d(const gkyl_ten_moment_grad_closure *gces,
   rhs[P33] = div_qx[5];
 }
 
-void
+GKYL_CU_D
+static void
 calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
   const double *fluid_d[], double *cflrate, double dt, double *q)
 {
@@ -325,7 +333,8 @@ calc_unmag_heat_flux_2d(const gkyl_ten_moment_grad_closure *gces,
   cflrate[0] = alpha*vth_avg*cfla;
 }
 
-void
+GKYL_CU_D
+static void
 grad_closure_update_2d(const gkyl_ten_moment_grad_closure *gces,
   const double *q[], double *rhs)
 {
@@ -373,7 +382,8 @@ grad_closure_update_2d(const gkyl_ten_moment_grad_closure *gces,
   rhs[P33] = div_qx[5] + div_qy[5];
 }
 
-void
+GKYL_CU_D
+static void
 calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
   const double *fluid_d[], double *cflrate, double dt, double *q)
 {
@@ -802,7 +812,8 @@ calc_unmag_heat_flux_3d(const gkyl_ten_moment_grad_closure *gces,
   cflrate[0] = alpha*vth_avg*cfla;
 }
 
-void
+GKYL_CU_D
+static void
 grad_closure_update_3d(const gkyl_ten_moment_grad_closure *gces,
   const double *q[], double *rhs)
 {
@@ -885,20 +896,24 @@ grad_closure_update_3d(const gkyl_ten_moment_grad_closure *gces,
   rhs[P33] = div_qx[5] + div_qy[5] + div_qz[5];
 }
 
+GKYL_CU_D
 static const heat_flux_calc_t grad_closure_unmag_funcs[3] = { calc_unmag_heat_flux_1d,
   calc_unmag_heat_flux_2d, calc_unmag_heat_flux_3d };
 
+GKYL_CU_D
 static const heat_flux_update_t grad_closure_update_funcs[3] = { grad_closure_update_1d,
   grad_closure_update_2d, grad_closure_update_3d };
 
-void
-grad_closure_calc_q_choose(struct gkyl_ten_moment_grad_closure *gces)
+GKYL_CU_D
+static void
+grad_closure_calc_q_choose(gkyl_ten_moment_grad_closure *gces)
 {
   gces->calc_q = grad_closure_unmag_funcs[gces->ndim - 1];
 }
 
-void
-grad_closure_update_q_choose(struct gkyl_ten_moment_grad_closure *gces)
+GKYL_CU_D
+static void
+grad_closure_update_q_choose(gkyl_ten_moment_grad_closure *gces)
 {
   gces->update_q = grad_closure_update_funcs[gces->ndim - 1];
 }

--- a/moments/zero/gkyl_ten_moment_grad_closure_priv.h
+++ b/moments/zero/gkyl_ten_moment_grad_closure_priv.h
@@ -12,6 +12,7 @@ struct gkyl_ten_moment_grad_closure {
   double k0; // damping coefficient
   double cfl; // CFL number to use
   double *cfla;
+  bool use_gpu; // Boolean to determine whether wave equation object is on host or device
   
   struct gkyl_comm *comm;
 
@@ -917,3 +918,35 @@ grad_closure_update_q_choose(gkyl_ten_moment_grad_closure *gces)
 {
   gces->update_q = grad_closure_update_funcs[gces->ndim - 1];
 }
+
+/**
+ * Create new updater to update pressure tensor in 10 moment equations
+ * using a symmetrized gradient-based closure, q_ijk ~ \partial_i [_i T_{jk}]
+ * Returns RHS for accumulation in a forward Euler method.
+ *
+ * @param gces Host side updater
+ */
+gkyl_ten_moment_grad_closure* gkyl_ten_moment_grad_closure_cu_dev_new(gkyl_ten_moment_grad_closure *gces);
+
+/**
+ * Compute RHS contribution from symmetrized gradient-based closure
+ * in 10 moment system.  The update_rng MUST be a sub-range of the
+ * range on which the array is defined.  That is, it must be either
+ * the same range as the array range, or one created using the
+ * gkyl_sub_range_init method.
+ *
+ * @param gces Gradient closure updater object.
+ * @param heat_flux_rng Range on which to compute heat flux tensor (cell nodes)
+ * @param update_rng Range on which to compute update.
+ * @param fluid Input array of fluid variables 
+ * @param em Total EM variables (plasma + external)
+ * @param cflrate CFL scalar rate (frequency: units of 1/[T]) 
+ * @param heat_flux Array for storing intermediate computation of heat flux tensor (cell nodes)
+ * @param rhs RHS output (NOTE: Returns RHS output of all nfluids)
+ */
+
+struct gkyl_ten_moment_grad_closure_status gkyl_ten_moment_grad_closure_advance_cu(
+  const gkyl_ten_moment_grad_closure *gces, const struct gkyl_range *heat_flux_range,
+  const struct gkyl_range *update_range, const struct gkyl_array *fluid,
+  const struct gkyl_array *em_tot, struct gkyl_array *cflrate, double dt,
+  struct gkyl_array *heat_flux, struct gkyl_array *rhs);

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -1,51 +1,10 @@
+#include <float.h>
+
 #include <gkyl_alloc.h>
 #include <gkyl_array_ops.h>
+#include <gkyl_null_comm.h>
 #include <gkyl_ten_moment_grad_closure.h>
-#include <gkyl_moment_non_ideal_priv.h>
-
-// Makes indexing cleaner
-static const unsigned T11 = 0;
-static const unsigned T12 = 1;
-static const unsigned T13 = 2;
-static const unsigned T22 = 3;
-static const unsigned T23 = 4;
-static const unsigned T33 = 5;
-
-static const unsigned Q111 = 0;
-static const unsigned Q112 = 1;
-static const unsigned Q113 = 2;
-static const unsigned Q122 = 3;
-static const unsigned Q123 = 4;
-static const unsigned Q133 = 5;
-static const unsigned Q222 = 6;
-static const unsigned Q223 = 7;
-static const unsigned Q233 = 8;
-static const unsigned Q333 = 9;
-
-// 1D stencil locations (L: lower, U: upper)
-enum loc_1d {
-  L_1D, U_1D
-};
-
-// 2D stencil locations (L: lower, U: upper)
-enum loc_2d {
-  LL_2D, LU_2D,
-  UL_2D, UU_2D
-};
-
-// 3D stencil locations (L: lower, U: upper)
-enum loc_3d {
-  LLL_3D, LLU_3D,
-  LUL_3D, LUU_3D,
-  ULL_3D, ULU_3D,
-  UUL_3D, UUU_3D
-};
-
-struct gkyl_ten_moment_grad_closure {
-  struct gkyl_rect_grid grid; // grid object
-  int ndim; // number of dimensions
-  double k0; // damping coefficient
-};
+#include <gkyl_ten_moment_grad_closure_priv.h>
 
 static void
 create_offsets_vertices(const struct gkyl_range *range, long offsets[])
@@ -79,252 +38,6 @@ create_offsets_centers(const struct gkyl_range *range, long offsets[])
     offsets[count++] = gkyl_range_offset(range, iter3.idx);
 }
 
-static void
-var_setup(const gkyl_ten_moment_grad_closure *gces,
-  int start, int end,
-  const double *fluid_d[],
-  double rho[], double p[], double Tij[][6])
-{
-  for (int j = start; j <= end; ++j) {
-    rho[j] = fluid_d[j][RHO];
-    p[j] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]
-          + fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]
-          + fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO])/3.0;
-    Tij[j][T11] = (fluid_d[j][P11] - fluid_d[j][MX] * fluid_d[j][MX] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-    Tij[j][T12] = (fluid_d[j][P12] - fluid_d[j][MX] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-    Tij[j][T13] = (fluid_d[j][P13] - fluid_d[j][MX] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-    Tij[j][T22] = (fluid_d[j][P22] - fluid_d[j][MY] * fluid_d[j][MY] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-    Tij[j][T23] = (fluid_d[j][P23] - fluid_d[j][MY] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-    Tij[j][T33] = (fluid_d[j][P33] - fluid_d[j][MZ] * fluid_d[j][MZ] / fluid_d[j][RHO]) / fluid_d[j][RHO];
-  }
-}
-
-static void
-calc_unmag_heat_flux(const gkyl_ten_moment_grad_closure *gces,
-  const double *fluid_d[], double *cflrate, double *heat_flux_d)
-{
-  const int ndim = gces->ndim;
-  double rho_avg = 0.0;
-  double p_avg = 0.0;
-  double dTdx[6] = {0.0};
-  double dTdy[6] = {0.0};
-  double dTdz[6] = {0.0};
-
-  if (ndim == 1) {
-    const double dx = gces->grid.dx[0];
-    double Tij[2][6] = {0.0};
-    double rho[2] = {0.0};
-    double p[2] = {0.0};
-    var_setup(gces, L_1D, U_1D, fluid_d, rho, p, Tij);
-
-    rho_avg = calc_harmonic_avg_1D(rho[L_1D], rho[U_1D]);
-    p_avg = calc_harmonic_avg_1D(p[L_1D], p[U_1D]);
-
-    dTdx[T11] = calc_sym_grad_1D(dx, Tij[L_1D][T11], Tij[U_1D][T11]);
-    dTdx[T12] = calc_sym_grad_1D(dx, Tij[L_1D][T12], Tij[U_1D][T12]);
-    dTdx[T13] = calc_sym_grad_1D(dx, Tij[L_1D][T13], Tij[U_1D][T13]);
-    dTdx[T22] = calc_sym_grad_1D(dx, Tij[L_1D][T22], Tij[U_1D][T22]);
-    dTdx[T23] = calc_sym_grad_1D(dx, Tij[L_1D][T23], Tij[U_1D][T23]);
-    dTdx[T33] = calc_sym_grad_1D(dx, Tij[L_1D][T33], Tij[U_1D][T33]);
-  }
-  else if (ndim == 2) {
-    const double dx = gces->grid.dx[0];
-    const double dy = gces->grid.dx[1];
-    double Tij[4][6] = {0.0};
-    double rho[4] = {0.0};
-    double p[4] = {0.0};
-    var_setup(gces, LL_2D, UU_2D, fluid_d, rho, p, Tij);
-
-    rho_avg = calc_harmonic_avg_2D(rho[LL_2D], rho[LU_2D], rho[UL_2D], rho[UU_2D]);
-    p_avg = calc_harmonic_avg_2D(p[LL_2D], p[LU_2D], p[UL_2D], p[UU_2D]);
-
-    dTdx[T11] = calc_sym_gradx_2D(dx, Tij[LL_2D][T11], Tij[LU_2D][T11], Tij[UL_2D][T11], Tij[UU_2D][T11]);
-    dTdx[T12] = calc_sym_gradx_2D(dx, Tij[LL_2D][T12], Tij[LU_2D][T12], Tij[UL_2D][T12], Tij[UU_2D][T12]);
-    dTdx[T13] = calc_sym_gradx_2D(dx, Tij[LL_2D][T13], Tij[LU_2D][T13], Tij[UL_2D][T13], Tij[UU_2D][T13]);
-    dTdx[T22] = calc_sym_gradx_2D(dx, Tij[LL_2D][T22], Tij[LU_2D][T22], Tij[UL_2D][T22], Tij[UU_2D][T22]);
-    dTdx[T23] = calc_sym_gradx_2D(dx, Tij[LL_2D][T23], Tij[LU_2D][T23], Tij[UL_2D][T23], Tij[UU_2D][T23]);
-    dTdx[T33] = calc_sym_gradx_2D(dx, Tij[LL_2D][T33], Tij[LU_2D][T33], Tij[UL_2D][T33], Tij[UU_2D][T33]);
-
-    dTdy[T11] = calc_sym_grady_2D(dy, Tij[LL_2D][T11], Tij[LU_2D][T11], Tij[UL_2D][T11], Tij[UU_2D][T11]);
-    dTdy[T12] = calc_sym_grady_2D(dy, Tij[LL_2D][T12], Tij[LU_2D][T12], Tij[UL_2D][T12], Tij[UU_2D][T12]);
-    dTdy[T13] = calc_sym_grady_2D(dy, Tij[LL_2D][T13], Tij[LU_2D][T13], Tij[UL_2D][T13], Tij[UU_2D][T13]);
-    dTdy[T22] = calc_sym_grady_2D(dy, Tij[LL_2D][T22], Tij[LU_2D][T22], Tij[UL_2D][T22], Tij[UU_2D][T22]);
-    dTdy[T23] = calc_sym_grady_2D(dy, Tij[LL_2D][T23], Tij[LU_2D][T23], Tij[UL_2D][T23], Tij[UU_2D][T23]);
-    dTdy[T33] = calc_sym_grady_2D(dy, Tij[LL_2D][T33], Tij[LU_2D][T33], Tij[UL_2D][T33], Tij[UU_2D][T33]);
-  }
-  else if (ndim == 3) {
-    const double dx = gces->grid.dx[0];
-    const double dy = gces->grid.dx[1];
-    const double dz = gces->grid.dx[2];
-
-    double Tij[8][6] = {0.0};
-    double rho[8] = {0.0};
-    double p[8] = {0.0};
-    var_setup(gces, LLL_3D, UUU_3D, fluid_d, rho, p, Tij);
-
-    rho_avg = calc_harmonic_avg_3D(rho[LLL_3D], rho[LLU_3D], rho[LUL_3D], rho[LUU_3D],
-                                   rho[ULL_3D], rho[ULU_3D], rho[UUL_3D], rho[UUU_3D]);
-    p_avg = calc_harmonic_avg_3D(p[LLL_3D], p[LLU_3D], p[LUL_3D], p[LUU_3D],
-                                 p[ULL_3D], p[ULU_3D], p[UUL_3D], p[UUU_3D]);
-
-    dTdx[T11] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T11], Tij[LLU_3D][T11], Tij[LUL_3D][T11], Tij[LUU_3D][T11],
-                                      Tij[ULL_3D][T11], Tij[ULU_3D][T11], Tij[UUL_3D][T11], Tij[UUU_3D][T11]);
-    dTdx[T12] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T12], Tij[LLU_3D][T12], Tij[LUL_3D][T12], Tij[LUU_3D][T12],
-                                      Tij[ULL_3D][T12], Tij[ULU_3D][T12], Tij[UUL_3D][T12], Tij[UUU_3D][T12]);
-    dTdx[T13] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T13], Tij[LLU_3D][T13], Tij[LUL_3D][T13], Tij[LUU_3D][T13],
-                                      Tij[ULL_3D][T13], Tij[ULU_3D][T13], Tij[UUL_3D][T13], Tij[UUU_3D][T13]);
-    dTdx[T22] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T22], Tij[LLU_3D][T22], Tij[LUL_3D][T22], Tij[LUU_3D][T22],
-                                      Tij[ULL_3D][T22], Tij[ULU_3D][T22], Tij[UUL_3D][T22], Tij[UUU_3D][T22]);
-    dTdx[T23] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T23], Tij[LLU_3D][T23], Tij[LUL_3D][T23], Tij[LUU_3D][T23],
-                                      Tij[ULL_3D][T23], Tij[ULU_3D][T23], Tij[UUL_3D][T23], Tij[UUU_3D][T23]);
-    dTdx[T33] = calc_sym_gradx_3D(dx, Tij[LLL_3D][T33], Tij[LLU_3D][T33], Tij[LUL_3D][T33], Tij[LUU_3D][T33],
-                                      Tij[ULL_3D][T33], Tij[ULU_3D][T33], Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
-
-    dTdy[T11] = calc_sym_grady_3D(dy, Tij[LLL_3D][T11], Tij[LLU_3D][T11], Tij[LUL_3D][T11], Tij[LUU_3D][T11],
-                                      Tij[ULL_3D][T11], Tij[ULU_3D][T11], Tij[UUL_3D][T11], Tij[UUU_3D][T11]);
-    dTdy[T12] = calc_sym_grady_3D(dy, Tij[LLL_3D][T12], Tij[LLU_3D][T12], Tij[LUL_3D][T12], Tij[LUU_3D][T12],
-                                      Tij[ULL_3D][T12], Tij[ULU_3D][T12], Tij[UUL_3D][T12], Tij[UUU_3D][T12]);
-    dTdy[T13] = calc_sym_grady_3D(dy, Tij[LLL_3D][T13], Tij[LLU_3D][T13], Tij[LUL_3D][T13], Tij[LUU_3D][T13],
-                                      Tij[ULL_3D][T13], Tij[ULU_3D][T13], Tij[UUL_3D][T13], Tij[UUU_3D][T13]);
-    dTdy[T22] = calc_sym_grady_3D(dy, Tij[LLL_3D][T22], Tij[LLU_3D][T22], Tij[LUL_3D][T22], Tij[LUU_3D][T22],
-                                      Tij[ULL_3D][T22], Tij[ULU_3D][T22], Tij[UUL_3D][T22], Tij[UUU_3D][T22]);
-    dTdy[T23] = calc_sym_grady_3D(dy, Tij[LLL_3D][T23], Tij[LLU_3D][T23], Tij[LUL_3D][T23], Tij[LUU_3D][T23],
-                                      Tij[ULL_3D][T23], Tij[ULU_3D][T23], Tij[UUL_3D][T23], Tij[UUU_3D][T23]);
-    dTdy[T33] = calc_sym_grady_3D(dy, Tij[LLL_3D][T33], Tij[LLU_3D][T33], Tij[LUL_3D][T33], Tij[LUU_3D][T33],
-                                      Tij[ULL_3D][T33], Tij[ULU_3D][T33], Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
-
-    dTdz[T11] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T11], Tij[LLU_3D][T11], Tij[LUL_3D][T11], Tij[LUU_3D][T11],
-                                      Tij[ULL_3D][T11], Tij[ULU_3D][T11], Tij[UUL_3D][T11], Tij[UUU_3D][T11]);
-    dTdz[T12] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T12], Tij[LLU_3D][T12], Tij[LUL_3D][T12], Tij[LUU_3D][T12],
-                                      Tij[ULL_3D][T12], Tij[ULU_3D][T12], Tij[UUL_3D][T12], Tij[UUU_3D][T12]);
-    dTdz[T13] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T13], Tij[LLU_3D][T13], Tij[LUL_3D][T13], Tij[LUU_3D][T13],
-                                      Tij[ULL_3D][T13], Tij[ULU_3D][T13], Tij[UUL_3D][T13], Tij[UUU_3D][T13]);
-    dTdz[T22] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T22], Tij[LLU_3D][T22], Tij[LUL_3D][T22], Tij[LUU_3D][T22],
-                                      Tij[ULL_3D][T22], Tij[ULU_3D][T22], Tij[UUL_3D][T22], Tij[UUU_3D][T22]);
-    dTdz[T23] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T23], Tij[LLU_3D][T23], Tij[LUL_3D][T23], Tij[LUU_3D][T23],
-                                      Tij[ULL_3D][T23], Tij[ULU_3D][T23], Tij[UUL_3D][T23], Tij[UUU_3D][T23]);
-    dTdz[T33] = calc_sym_gradz_3D(dz, Tij[LLL_3D][T33], Tij[LLU_3D][T33], Tij[LUL_3D][T33], Tij[LUU_3D][T33],
-                                      Tij[ULL_3D][T33], Tij[ULU_3D][T33], Tij[UUL_3D][T33], Tij[UUU_3D][T33]);
-  }
-  double alpha = 1.0/gces->k0;
-  double vth_avg = sqrt(p_avg/rho_avg);
-  heat_flux_d[Q111] = alpha*vth_avg*rho_avg*(dTdx[T11] + dTdx[T11] + dTdx[T11])/3.0;
-  heat_flux_d[Q112] = alpha*vth_avg*rho_avg*(dTdx[T12] + dTdx[T12] + dTdy[T11])/3.0;
-  heat_flux_d[Q113] = alpha*vth_avg*rho_avg*(dTdx[T13] + dTdx[T13] + dTdz[T11])/3.0;
-  heat_flux_d[Q122] = alpha*vth_avg*rho_avg*(dTdx[T22] + dTdy[T12] + dTdy[T12])/3.0;
-  heat_flux_d[Q123] = alpha*vth_avg*rho_avg*(dTdx[T23] + dTdy[T13] + dTdz[T12])/3.0;
-  heat_flux_d[Q133] = alpha*vth_avg*rho_avg*(dTdx[T33] + dTdz[T13] + dTdz[T13])/3.0;
-  heat_flux_d[Q222] = alpha*vth_avg*rho_avg*(dTdy[T22] + dTdy[T22] + dTdy[T22])/3.0;
-  heat_flux_d[Q223] = alpha*vth_avg*rho_avg*(dTdy[T23] + dTdy[T23] + dTdz[T22])/3.0;
-  heat_flux_d[Q233] = alpha*vth_avg*rho_avg*(dTdy[T33] + dTdz[T23] + dTdz[T23])/3.0;
-  heat_flux_d[Q333] = alpha*vth_avg*rho_avg*(dTdz[T33] + dTdz[T33] + dTdz[T33])/3.0;
-}
-
-static void
-calc_grad_closure_update(const gkyl_ten_moment_grad_closure *gces,
-  const double *heat_flux_d[], double *rhs)
-{
-  const int ndim = gces->ndim;
-  double divQx[6] = {0.0};
-  double divQy[6] = {0.0};
-  double divQz[6] = {0.0};
-
-  if (ndim == 1) {
-    const double dx = gces->grid.dx[0];
-    double q[2][10] = {0.0};
-    for (int j = L_1D; j <= U_1D; ++j)
-      for (int k = 0; k < 10; ++k)
-        q[j][k] = heat_flux_d[j][k];
-
-    divQx[0] = calc_sym_grad_1D(dx, q[L_1D][Q111], q[U_1D][Q111]);
-    divQx[1] = calc_sym_grad_1D(dx, q[L_1D][Q112], q[U_1D][Q112]);
-    divQx[2] = calc_sym_grad_1D(dx, q[L_1D][Q113], q[U_1D][Q113]);
-    divQx[3] = calc_sym_grad_1D(dx, q[L_1D][Q122], q[U_1D][Q122]);
-    divQx[4] = calc_sym_grad_1D(dx, q[L_1D][Q123], q[U_1D][Q123]);
-    divQx[5] = calc_sym_grad_1D(dx, q[L_1D][Q133], q[U_1D][Q133]);
-  }
-  else if (ndim == 2) {
-    const double dx = gces->grid.dx[0];
-    const double dy = gces->grid.dx[1];
-    double q[4][10] = {0.0};
-    for (int j = LL_2D; j <= UU_2D; ++j)
-      for (int k = 0; k < 10; ++k)
-        q[j][k] = heat_flux_d[j][k];
-
-    divQx[0] = calc_sym_gradx_2D(dx, q[LL_2D][Q111], q[LU_2D][Q111], q[UL_2D][Q111], q[UU_2D][Q111]);
-    divQx[1] = calc_sym_gradx_2D(dx, q[LL_2D][Q112], q[LU_2D][Q112], q[UL_2D][Q112], q[UU_2D][Q112]);
-    divQx[2] = calc_sym_gradx_2D(dx, q[LL_2D][Q113], q[LU_2D][Q113], q[UL_2D][Q113], q[UU_2D][Q113]);
-    divQx[3] = calc_sym_gradx_2D(dx, q[LL_2D][Q122], q[LU_2D][Q122], q[UL_2D][Q122], q[UU_2D][Q122]);
-    divQx[4] = calc_sym_gradx_2D(dx, q[LL_2D][Q123], q[LU_2D][Q123], q[UL_2D][Q123], q[UU_2D][Q123]);
-    divQx[5] = calc_sym_gradx_2D(dx, q[LL_2D][Q133], q[LU_2D][Q133], q[UL_2D][Q133], q[UU_2D][Q133]);
-
-    divQy[0] = calc_sym_grady_2D(dy, q[LL_2D][Q112], q[LU_2D][Q112], q[UL_2D][Q112], q[UU_2D][Q112]);
-    divQy[1] = calc_sym_grady_2D(dy, q[LL_2D][Q122], q[LU_2D][Q122], q[UL_2D][Q122], q[UU_2D][Q122]);
-    divQy[2] = calc_sym_grady_2D(dy, q[LL_2D][Q123], q[LU_2D][Q123], q[UL_2D][Q123], q[UU_2D][Q123]);
-    divQy[3] = calc_sym_grady_2D(dy, q[LL_2D][Q222], q[LU_2D][Q222], q[UL_2D][Q222], q[UU_2D][Q222]);
-    divQy[4] = calc_sym_grady_2D(dy, q[LL_2D][Q223], q[LU_2D][Q223], q[UL_2D][Q223], q[UU_2D][Q223]);
-    divQy[5] = calc_sym_grady_2D(dy, q[LL_2D][Q233], q[LU_2D][Q233], q[UL_2D][Q233], q[UU_2D][Q233]);
-  }
-  else if (ndim == 3) {
-    const double dx = gces->grid.dx[0];
-    const double dy = gces->grid.dx[1];
-    const double dz = gces->grid.dx[2];
-    double q[8][10] = {0.0};
-    for (int j = LLL_3D; j <= UUU_3D; ++j)
-      for (int k = 0; k < 10; ++k)
-        q[j][k] = heat_flux_d[j][k];
-
-    divQx[0] = calc_sym_gradx_3D(dx, q[LLL_3D][Q111], q[LLU_3D][Q111], q[LUL_3D][Q111], q[LUU_3D][Q111],
-                                     q[ULL_3D][Q111], q[ULU_3D][Q111], q[UUL_3D][Q111], q[UUU_3D][Q111]);
-    divQx[1] = calc_sym_gradx_3D(dx, q[LLL_3D][Q112], q[LLU_3D][Q112], q[LUL_3D][Q112], q[LUU_3D][Q112],
-                                     q[ULL_3D][Q112], q[ULU_3D][Q112], q[UUL_3D][Q112], q[UUU_3D][Q112]);
-    divQx[2] = calc_sym_gradx_3D(dx, q[LLL_3D][Q113], q[LLU_3D][Q113], q[LUL_3D][Q113], q[LUU_3D][Q113],
-                                     q[ULL_3D][Q113], q[ULU_3D][Q113], q[UUL_3D][Q113], q[UUU_3D][Q113]);
-    divQx[3] = calc_sym_gradx_3D(dx, q[LLL_3D][Q122], q[LLU_3D][Q122], q[LUL_3D][Q122], q[LUU_3D][Q122],
-                                     q[ULL_3D][Q122], q[ULU_3D][Q122], q[UUL_3D][Q122], q[UUU_3D][Q122]);
-    divQx[4] = calc_sym_gradx_3D(dx, q[LLL_3D][Q123], q[LLU_3D][Q123], q[LUL_3D][Q123], q[LUU_3D][Q123],
-                                     q[ULL_3D][Q123], q[ULU_3D][Q123], q[UUL_3D][Q123], q[UUU_3D][Q123]);
-    divQx[5] = calc_sym_gradx_3D(dx, q[LLL_3D][Q133], q[LLU_3D][Q133], q[LUL_3D][Q133], q[LUU_3D][Q133],
-                                     q[ULL_3D][Q133], q[ULU_3D][Q133], q[UUL_3D][Q133], q[UUU_3D][Q133]);
-
-    divQy[0] = calc_sym_grady_3D(dy, q[LLL_3D][Q112], q[LLU_3D][Q112], q[LUL_3D][Q112], q[LUU_3D][Q112],
-                                     q[ULL_3D][Q112], q[ULU_3D][Q112], q[UUL_3D][Q112], q[UUU_3D][Q112]);
-    divQy[1] = calc_sym_grady_3D(dy, q[LLL_3D][Q122], q[LLU_3D][Q122], q[LUL_3D][Q122], q[LUU_3D][Q122],
-                                     q[ULL_3D][Q122], q[ULU_3D][Q122], q[UUL_3D][Q122], q[UUU_3D][Q122]);
-    divQy[2] = calc_sym_grady_3D(dy, q[LLL_3D][Q123], q[LLU_3D][Q123], q[LUL_3D][Q123], q[LUU_3D][Q123],
-                                     q[ULL_3D][Q123], q[ULU_3D][Q123], q[UUL_3D][Q123], q[UUU_3D][Q123]);
-    divQy[3] = calc_sym_grady_3D(dy, q[LLL_3D][Q222], q[LLU_3D][Q222], q[LUL_3D][Q222], q[LUU_3D][Q222],
-                                     q[ULL_3D][Q222], q[ULU_3D][Q222], q[UUL_3D][Q222], q[UUU_3D][Q222]);
-    divQy[4] = calc_sym_grady_3D(dy, q[LLL_3D][Q223], q[LLU_3D][Q223], q[LUL_3D][Q223], q[LUU_3D][Q223],
-                                     q[ULL_3D][Q223], q[ULU_3D][Q223], q[UUL_3D][Q223], q[UUU_3D][Q223]);
-    divQy[5] = calc_sym_grady_3D(dy, q[LLL_3D][Q233], q[LLU_3D][Q233], q[LUL_3D][Q233], q[LUU_3D][Q233],
-                                     q[ULL_3D][Q233], q[ULU_3D][Q233], q[UUL_3D][Q233], q[UUU_3D][Q233]);
-
-    divQz[0] = calc_sym_gradz_3D(dz, q[LLL_3D][Q113], q[LLU_3D][Q113], q[LUL_3D][Q113], q[LUU_3D][Q113],
-                                     q[ULL_3D][Q113], q[ULU_3D][Q113], q[UUL_3D][Q113], q[UUU_3D][Q113]);
-    divQz[1] = calc_sym_gradz_3D(dz, q[LLL_3D][Q123], q[LLU_3D][Q123], q[LUL_3D][Q123], q[LUU_3D][Q123],
-                                     q[ULL_3D][Q123], q[ULU_3D][Q123], q[UUL_3D][Q123], q[UUU_3D][Q123]);
-    divQz[2] = calc_sym_gradz_3D(dz, q[LLL_3D][Q133], q[LLU_3D][Q133], q[LUL_3D][Q133], q[LUU_3D][Q133],
-                                     q[ULL_3D][Q133], q[ULU_3D][Q133], q[UUL_3D][Q133], q[UUU_3D][Q133]);
-    divQz[3] = calc_sym_gradz_3D(dz, q[LLL_3D][Q223], q[LLU_3D][Q223], q[LUL_3D][Q223], q[LUU_3D][Q223],
-                                     q[ULL_3D][Q223], q[ULU_3D][Q223], q[UUL_3D][Q223], q[UUU_3D][Q223]);
-    divQz[4] = calc_sym_gradz_3D(dz, q[LLL_3D][Q233], q[LLU_3D][Q233], q[LUL_3D][Q233], q[LUU_3D][Q233],
-                                     q[ULL_3D][Q233], q[ULU_3D][Q233], q[UUL_3D][Q233], q[UUU_3D][Q233]);
-    divQz[5] = calc_sym_gradz_3D(dz, q[LLL_3D][Q333], q[LLU_3D][Q333], q[LUL_3D][Q333], q[LUU_3D][Q333],
-                                     q[ULL_3D][Q333], q[ULU_3D][Q333], q[UUL_3D][Q333], q[UUU_3D][Q333]);
-  }
-  rhs[RHO] = 0.0;
-  rhs[MX] = 0.0;
-  rhs[MY] = 0.0;
-  rhs[MZ] = 0.0;
-  rhs[P11] = divQx[0] + divQy[0] + divQz[0];
-  rhs[P12] = divQx[1] + divQy[1] + divQz[1];
-  rhs[P13] = divQx[2] + divQy[2] + divQz[2];
-  rhs[P22] = divQx[3] + divQy[3] + divQz[3];
-  rhs[P23] = divQx[4] + divQy[4] + divQz[4];
-  rhs[P33] = divQx[5] + divQy[5] + divQz[5];
-}
-
 gkyl_ten_moment_grad_closure*
 gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
 {
@@ -333,19 +46,32 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
   up->grid = *(inp.grid);
   up->ndim = up->grid.ndim;
   up->k0 = inp.k0;
+  up->cfl = inp.cfl;
 
+  if (inp.comm)
+    up->comm = gkyl_comm_acquire(inp.comm);
+  else
+    up->comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) { } );
+
+  grad_closure_calc_q_choose(up);
+  
   return up;
 }
 
-void
+struct gkyl_ten_moment_grad_closure_status
 gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
   const struct gkyl_range *heat_flux_range, const struct gkyl_range *update_range,
   const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
-  struct gkyl_array *cflrate, struct gkyl_array *heat_flux,
+  struct gkyl_array *cflrate, double dt, struct gkyl_array *heat_flux,
   struct gkyl_array *rhs)
 {
   int ndim = update_range->ndim;
   long sz[] = { 2, 4, 8 };
+
+  double cfla = 0.0, cfl = gces->cfl, cflm = 1.1*cfl;
+  double is_cfl_violated = 0.0; // deliberately a double
+
+  gkyl_array_clear(rhs, 0.0);
 
   long offsets_vertices[sz[ndim-1]];
   create_offsets_vertices(update_range, offsets_vertices);
@@ -355,9 +81,7 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
 
   const double* fluid_d[sz[ndim-1]];
   const double* em_tot_d[sz[ndim-1]];
-  double *heat_flux_d;
-  const double* heat_flux_up[sz[ndim-1]];
-  double *rhs_d;
+  double *rhs_d[sz[ndim-1]];
 
   struct gkyl_range_iter iter_vertex;
   gkyl_range_iter_init(&iter_vertex, heat_flux_range);
@@ -369,31 +93,46 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
     for (int i=0; i<sz[ndim-1]; ++i) {
       em_tot_d[i] =  gkyl_array_cfetch(em_tot, linc_center + offsets_vertices[i]);
       fluid_d[i] = gkyl_array_cfetch(fluid, linc_center + offsets_vertices[i]);
+      rhs_d[i] = gkyl_array_fetch(rhs, linc_center + offsets_vertices[i]);
     }
 
-    heat_flux_d = gkyl_array_fetch(heat_flux, linc_vertex);
-
-    calc_unmag_heat_flux(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center), heat_flux_d);
+    cfla = gces->calc_q(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center),
+      cfla, dt, rhs_d);
   }
 
-  struct gkyl_range_iter iter_center;
-  gkyl_range_iter_init(&iter_center, update_range);
-  while (gkyl_range_iter_next(&iter_center)) {
+  if (cfla > cflm)
+    is_cfl_violated = 1.0;
 
-    long linc_vertex = gkyl_range_idx(heat_flux_range, iter_center.idx);
-    long linc_center = gkyl_range_idx(update_range, iter_center.idx);
+  // compute actual CFL, status & max-speed across all domains
+  double red_vars[2] = { cfla, is_cfl_violated };
+  double red_vars_global[2] = { 0.0, 0.0 };
+  gkyl_comm_allreduce(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars, &red_vars_global);
 
-    for (int i=0; i<sz[ndim-1]; ++i)
-      heat_flux_up[i] = gkyl_array_fetch(heat_flux, linc_vertex + offsets_centers[i]);
+  cfla = red_vars_global[0];
+  is_cfl_violated = red_vars_global[1];
 
-    rhs_d = gkyl_array_fetch(rhs, linc_center);
+  double dt_suggested = dt*cfl/fmax(cfla, DBL_MIN);
 
-    calc_grad_closure_update(gces, heat_flux_up, rhs_d);
-  }
+  if (is_cfl_violated > 0.0)
+    // indicate failure, and return smaller stable time-step
+    return (struct gkyl_ten_moment_grad_closure_status) {
+      .success = 0,
+      .dt_suggested = dt_suggested,
+    };
+
+  // on success, suggest only bigger time-step; (Only way dt can
+  // reduce is if the update fails. If the code comes here the update
+  // succeeded and so we should not allow dt to reduce).
+  return (struct gkyl_ten_moment_grad_closure_status) {
+    .success = is_cfl_violated > 0.0 ? 0 : 1,
+    .dt_suggested = dt_suggested > dt ? dt_suggested : dt,
+  };
+
 }
 
 void
 gkyl_ten_moment_grad_closure_release(gkyl_ten_moment_grad_closure* up)
 {
+  gkyl_comm_release(up->comm);
   free(up);
 }

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -171,7 +171,7 @@ gkyl_ten_moment_grad_closure_release(gkyl_ten_moment_grad_closure* up)
   gkyl_comm_release(up->comm);
   gkyl_free(up->cfla);
   if (up->use_gpu) {
-    gkyl_cu_free(up->on_dev.cfla);
+    gkyl_cu_free(up->on_dev->cfla);
     gkyl_free(up->on_dev);
   }
   gkyl_free(up);

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -49,6 +49,8 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
   up->k0 = inp.k0;
   up->cfl = inp.cfl;
 
+  up->cfla = gkyl_malloc(sizeof(double));
+  
   if (inp.comm)
     up->comm = gkyl_comm_acquire(inp.comm);
   else
@@ -69,7 +71,7 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
   int ndim = update_range->ndim;
   long sz[] = { 2, 4, 8 };
 
-  double cfla[1] = { 0.0 };
+  double *cfla = gces->cfla;
   double cfl = gces->cfl, cflm = 1.1*cfl;
   double is_cfl_violated = 0.0; // deliberately a double
 
@@ -109,7 +111,8 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
   // compute actual CFL, status & max-speed across all domains
   double red_vars[2] = { cfla[0], is_cfl_violated };
   double red_vars_global[2] = { 0.0, 0.0 };
-  gkyl_comm_allreduce(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars, &red_vars_global);
+  gkyl_comm_allreduce(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, red_vars,
+    red_vars_global);
 
   cfla[0] = red_vars_global[0];
   is_cfl_violated = red_vars_global[1];
@@ -137,5 +140,6 @@ void
 gkyl_ten_moment_grad_closure_release(gkyl_ten_moment_grad_closure* up)
 {
   gkyl_comm_release(up->comm);
+  gkyl_free(up->cfla);
   free(up);
 }

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -57,6 +57,7 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
     up->comm = gkyl_null_comm_inew( &(struct gkyl_null_comm_inp) { } );
 
   grad_closure_calc_q_choose(up);
+  grad_closure_update_q_choose(up);
   
   return up;
 }
@@ -75,8 +76,6 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
   double cfl = gces->cfl, cflm = 1.1*cfl;
   double is_cfl_violated = 0.0; // deliberately a double
 
-  gkyl_array_clear(rhs, 0.0);
-
   long offsets_vertices[sz[ndim-1]];
   create_offsets_vertices(update_range, offsets_vertices);
 
@@ -85,7 +84,9 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
 
   const double* fluid_d[sz[ndim-1]];
   const double* em_tot_d[sz[ndim-1]];
-  double *rhs_d[sz[ndim-1]];
+  double *heat_flux_d;
+  const double* heat_flux_up[sz[ndim-1]];
+  double *rhs_d;
 
   struct gkyl_range_iter iter_vertex;
   gkyl_range_iter_init(&iter_vertex, heat_flux_range);
@@ -97,10 +98,27 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
     for (int i=0; i<sz[ndim-1]; ++i) {
       em_tot_d[i] =  gkyl_array_cfetch(em_tot, linc_center + offsets_vertices[i]);
       fluid_d[i] = gkyl_array_cfetch(fluid, linc_center + offsets_vertices[i]);
-      rhs_d[i] = gkyl_array_fetch(rhs, linc_center + offsets_vertices[i]);
     }
 
-    gces->calc_q(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center), dt, rhs_d);
+    heat_flux_d = gkyl_array_fetch(heat_flux, linc_vertex);
+
+    gces->calc_q(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center), dt, heat_flux_d);
+  }
+
+  struct gkyl_range_iter iter_center;
+  gkyl_range_iter_init(&iter_center, update_range);
+  while (gkyl_range_iter_next(&iter_center)) {
+
+    long linc_vertex = gkyl_range_idx(heat_flux_range, iter_center.idx);
+    long linc_center = gkyl_range_idx(update_range, iter_center.idx);
+
+    for (int i=0; i<sz[ndim-1]; ++i)
+      heat_flux_up[i] = gkyl_array_fetch(heat_flux, linc_vertex + offsets_centers[i]);
+
+
+    rhs_d = gkyl_array_fetch(rhs, linc_center);
+
+    gces->update_q(gces, heat_flux_up, rhs_d);
   }
 
   gkyl_array_reduce(cfla, cflrate, GKYL_MAX);
@@ -125,7 +143,6 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
       .success = 0,
       .dt_suggested = dt_suggested,
     };
-
   // on success, suggest only bigger time-step; (Only way dt can
   // reduce is if the update fails. If the code comes here the update
   // succeeded and so we should not allow dt to reduce).

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -17,6 +17,17 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
   up->k0 = inp.k0;
   up->cfl = inp.cfl;
   up->use_gpu = inp.use_gpu;
+
+  int ndim = inp.update_range->ndim;
+  long sz[] = { 2, 4, 8 };
+
+  up->sz_idx = sz[ndim-1];
+
+  long offsets_vertices[sz[ndim-1]];
+  create_offsets_vertices(inp.update_range, offsets_vertices);
+
+  long offsets_centers[sz[ndim-1]];
+  create_offsets_centers(inp.heat_flux_range, offsets_centers);
   
   if (inp.comm)
     up->comm = gkyl_comm_acquire(inp.comm);
@@ -28,9 +39,14 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
 
   if(inp.use_gpu) {
     up->cfla = gkyl_cu_malloc(sizeof(double));
-    up->offsets_vertices = gkyl_cu_malloc(sizeof(long)*8);
-    up->offsets_centers = gkyl_cu_malloc(sizeof(long)*8);
+    up->offsets_vertices = gkyl_cu_malloc(sizeof(long)*sz[ndim-1]);
+    up->offsets_centers = gkyl_cu_malloc(sizeof(long)*sz[ndim-1]);
     up->on_dev = gkyl_ten_moment_grad_closure_cu_dev_new(up);
+
+    gkyl_cu_memcpy(up->offsets_vertices, offsets_vertices, sizeof(long)*sz[ndim-1],
+      GKYL_CU_MEMCPY_H2D);
+    gkyl_cu_memcpy(up->offsets_centers, offsets_centers, sizeof(long)*sz[ndim-1],
+      GKYL_CU_MEMCPY_H2D);
   }
   else {
     up->cfla = gkyl_malloc(sizeof(double));

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -2,6 +2,7 @@
 
 #include <gkyl_alloc.h>
 #include <gkyl_array_ops.h>
+#include <gkyl_array_reduce.h>
 #include <gkyl_null_comm.h>
 #include <gkyl_ten_moment_grad_closure.h>
 #include <gkyl_ten_moment_grad_closure_priv.h>
@@ -68,7 +69,8 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
   int ndim = update_range->ndim;
   long sz[] = { 2, 4, 8 };
 
-  double cfla = 0.0, cfl = gces->cfl, cflm = 1.1*cfl;
+  double cfla[1] = { 0.0 };
+  double cfl = gces->cfl, cflm = 1.1*cfl;
   double is_cfl_violated = 0.0; // deliberately a double
 
   gkyl_array_clear(rhs, 0.0);
@@ -96,22 +98,23 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
       rhs_d[i] = gkyl_array_fetch(rhs, linc_center + offsets_vertices[i]);
     }
 
-    cfla = gces->calc_q(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center),
-      cfla, dt, rhs_d);
+    gces->calc_q(gces, fluid_d, gkyl_array_fetch(cflrate, linc_center), dt, rhs_d);
   }
 
-  if (cfla > cflm)
+  gkyl_array_reduce(cfla, cflrate, GKYL_MAX);
+
+  if (cfla[0] > cflm)
     is_cfl_violated = 1.0;
 
   // compute actual CFL, status & max-speed across all domains
-  double red_vars[2] = { cfla, is_cfl_violated };
+  double red_vars[2] = { cfla[0], is_cfl_violated };
   double red_vars_global[2] = { 0.0, 0.0 };
   gkyl_comm_allreduce(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars, &red_vars_global);
 
-  cfla = red_vars_global[0];
+  cfla[0] = red_vars_global[0];
   is_cfl_violated = red_vars_global[1];
 
-  double dt_suggested = dt*cfl/fmax(cfla, DBL_MIN);
+  double dt_suggested = dt*cfl/fmax(cfla[0], DBL_MIN);
 
   if (is_cfl_violated > 0.0)
     // indicate failure, and return smaller stable time-step

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -48,8 +48,7 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
   up->ndim = up->grid.ndim;
   up->k0 = inp.k0;
   up->cfl = inp.cfl;
-
-  up->cfla = gkyl_malloc(sizeof(double));
+  up->use_gpu = inp.use_gpu;
   
   if (inp.comm)
     up->comm = gkyl_comm_acquire(inp.comm);
@@ -58,6 +57,14 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
 
   grad_closure_calc_q_choose(up);
   grad_closure_update_q_choose(up);
+
+  if(inp.use_gpu) {
+    up->cfla = gkyl_cu_malloc(sizeof(double));
+    up->on_dev = gkyl_ten_moment_grad_closure_cu_dev_new(up);
+  }
+  else {
+    up->cfla = gkyl_malloc(sizeof(double));
+  }
   
   return up;
 }
@@ -69,6 +76,11 @@ gkyl_ten_moment_grad_closure_advance(const gkyl_ten_moment_grad_closure *gces,
   struct gkyl_array *cflrate, double dt, struct gkyl_array *heat_flux,
   struct gkyl_array *rhs)
 {
+  if (gces->use_gpu) {
+    return gkyl_ten_moment_grad_closure_advance_cu(gces, heat_flux_range, update_range,
+      fluid, em_tot, cflrate, dt, heat_flux, rhs); 
+  }
+
   int ndim = update_range->ndim;
   long sz[] = { 2, 4, 8 };
 
@@ -158,5 +170,9 @@ gkyl_ten_moment_grad_closure_release(gkyl_ten_moment_grad_closure* up)
 {
   gkyl_comm_release(up->comm);
   gkyl_free(up->cfla);
-  free(up);
+  if (up->use_gpu) {
+    gkyl_cu_free(up->on_dev.cfla);
+    gkyl_free(up->on_dev);
+  }
+  gkyl_free(up);
 }

--- a/moments/zero/ten_moment_grad_closure.c
+++ b/moments/zero/ten_moment_grad_closure.c
@@ -7,38 +7,6 @@
 #include <gkyl_ten_moment_grad_closure.h>
 #include <gkyl_ten_moment_grad_closure_priv.h>
 
-static void
-create_offsets_vertices(const struct gkyl_range *range, long offsets[])
-{
-  // box spanning stencil
-  struct gkyl_range box3;
-  gkyl_range_init(&box3, range->ndim, (int[]) { -1, -1, -1 }, (int[]) { 0, 0, 0 });
-
-  struct gkyl_range_iter iter3;
-  gkyl_range_iter_init(&iter3, &box3);
-
-  // construct list of offsets
-  int count = 0;
-  while (gkyl_range_iter_next(&iter3))
-    offsets[count++] = gkyl_range_offset(range, iter3.idx);
-}
-
-static void
-create_offsets_centers(const struct gkyl_range *range, long offsets[])
-{
-  // box spanning stencil
-  struct gkyl_range box3;
-  gkyl_range_init(&box3, range->ndim, (int[]) { 0, 0, 0 }, (int[]) { 1, 1, 1 });
-
-  struct gkyl_range_iter iter3;
-  gkyl_range_iter_init(&iter3, &box3);
-
-  // construct list of offsets
-  int count = 0;
-  while (gkyl_range_iter_next(&iter3))
-    offsets[count++] = gkyl_range_offset(range, iter3.idx);
-}
-
 gkyl_ten_moment_grad_closure*
 gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
 {
@@ -60,6 +28,8 @@ gkyl_ten_moment_grad_closure_new(struct gkyl_ten_moment_grad_closure_inp inp)
 
   if(inp.use_gpu) {
     up->cfla = gkyl_cu_malloc(sizeof(double));
+    up->offsets_vertices = gkyl_cu_malloc(sizeof(long)*8);
+    up->offsets_centers = gkyl_cu_malloc(sizeof(long)*8);
     up->on_dev = gkyl_ten_moment_grad_closure_cu_dev_new(up);
   }
   else {

--- a/moments/zero/ten_moment_grad_closure_cu.cu
+++ b/moments/zero/ten_moment_grad_closure_cu.cu
@@ -124,12 +124,8 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
   gkyl_cu_memcpy(gces->offsets_centers, offsets_centers, sizeof(long)*sz_idx, GKYL_CU_MEMCPY_H2D);
 
   gkyl_ten_moment_grad_closure_calc_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
-    *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers, sz_idx,
-    fluid->on_dev, em_tot->on_dev, cflrate->on_dev, dt, heat_flux->on_dev);
-
-  gkyl_ten_moment_grad_closure_update_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
-    *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers, sz_idx,
-     heat_flux->on_dev, rhs->on_dev);
+    *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers,
+    sz_idx, fluid->on_dev, em_tot->on_dev, cflrate->on_dev, dt, heat_flux->on_dev);
 
   gkyl_array_reduce(gces->cfla, cflrate, GKYL_MAX);
   gkyl_cu_memcpy(cfla, gces->cfla, sizeof(double), GKYL_CU_MEMCPY_D2H);
@@ -155,11 +151,15 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
       .dt_suggested = dt_suggested,
     };
 
+  gkyl_ten_moment_grad_closure_update_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
+    *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers,
+     sz_idx, heat_flux->on_dev, rhs->on_dev);
+
   // on success, suggest only bigger time-step; (Only way dt can
   // reduce is if the update fails. If the code comes here the update
   // succeeded and so we should not allow dt to reduce).
   return (struct gkyl_ten_moment_grad_closure_status) {
-    .success = is_cfl_violated > 0.0 ? 0 : 1,
+    .success = 1,
     .dt_suggested = dt_suggested > dt ? dt_suggested : dt,
   };
 

--- a/moments/zero/ten_moment_grad_closure_cu.cu
+++ b/moments/zero/ten_moment_grad_closure_cu.cu
@@ -20,9 +20,9 @@ gkyl_ten_moment_grad_closure_set_cu_dev_ptrs(gkyl_ten_moment_grad_closure *gces)
 __global__ static void
 gkyl_ten_moment_grad_closure_calc_cu_ker(const gkyl_ten_moment_grad_closure *gces,
   const struct gkyl_range heat_flux_range, const struct gkyl_range update_range,
-  long *offsets_vertices, long *offsets_centers, int sz_idx,
-  const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
-  struct gkyl_array *cflrate, double dt, struct gkyl_array *heat_flux)
+  long *offsets_vertices, long *offsets_centers, const struct gkyl_array *fluid,
+  const struct gkyl_array *em_tot, struct gkyl_array *cflrate, double dt,
+  struct gkyl_array *heat_flux)
 {
   const double* fluid_d[8];
   const double* em_tot_d[8];
@@ -38,7 +38,7 @@ gkyl_ten_moment_grad_closure_calc_cu_ker(const gkyl_ten_moment_grad_closure *gce
     long linc_vertex = gkyl_range_idx(&heat_flux_range, vidx);
     long linc_center = gkyl_range_idx(&update_range, vidx);
 
-    for (int i=0; i<sz_idx; ++i) {
+    for (int i=0; i<gces->sz_idx; ++i) {
       em_tot_d[i] =  (const double*) gkyl_array_cfetch(em_tot,
         linc_center + offsets_vertices[i]);
       fluid_d[i] = (const double*) gkyl_array_cfetch(fluid,
@@ -55,8 +55,8 @@ gkyl_ten_moment_grad_closure_calc_cu_ker(const gkyl_ten_moment_grad_closure *gce
 __global__ static void
 gkyl_ten_moment_grad_closure_update_cu_ker(const gkyl_ten_moment_grad_closure *gces,
   const struct gkyl_range heat_flux_range, const struct gkyl_range update_range,
-  long *offsets_vertices, long *offsets_centers, int sz_idx,
-  const struct gkyl_array *heat_flux, struct gkyl_array *rhs)
+  long *offsets_vertices, long *offsets_centers, const struct gkyl_array *heat_flux,
+  struct gkyl_array *rhs)
 {
   const double* heat_flux_up[8];
   
@@ -70,7 +70,7 @@ gkyl_ten_moment_grad_closure_update_cu_ker(const gkyl_ten_moment_grad_closure *g
     long linc_vertex = gkyl_range_idx(&heat_flux_range, cidx);
     long linc_center = gkyl_range_idx(&update_range, cidx);
 
-    for (int i=0; i<sz_idx; ++i)
+    for (int i=0; i<gces->sz_idx; ++i)
       heat_flux_up[i] = (const double*) gkyl_array_cfetch(heat_flux,
         linc_vertex + offsets_centers[i]);
 
@@ -108,23 +108,9 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
   // gkyl_cu_memcpy(cfl, gces->cfl, sizeof(double), GKYL_CU_MEMCPY_D2H); // probably don't actually need this? Don't think there's any reason for cfl to be needed on device.
   double cflm = 1.1*gces->cfl;
 
-  int ndim = update_range->ndim;
-  long sz[] = { 2, 4, 8 };
-
-  int sz_idx = sz[ndim-1];
-
-  long offsets_vertices[sz_idx];
-  create_offsets_vertices(update_range, offsets_vertices);
-
-  long offsets_centers[sz_idx];
-  create_offsets_centers(heat_flux_range, offsets_centers);
-
-  gkyl_cu_memcpy(gces->offsets_vertices, offsets_vertices, sizeof(long)*sz_idx, GKYL_CU_MEMCPY_H2D);
-  gkyl_cu_memcpy(gces->offsets_centers, offsets_centers, sizeof(long)*sz_idx, GKYL_CU_MEMCPY_H2D);
-
   gkyl_ten_moment_grad_closure_calc_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
     *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers,
-    sz_idx, fluid->on_dev, em_tot->on_dev, cflrate->on_dev, dt, heat_flux->on_dev);
+    fluid->on_dev, em_tot->on_dev, cflrate->on_dev, dt, heat_flux->on_dev);
 
   gkyl_array_reduce(gces->cfla, cflrate, GKYL_MAX);
   gkyl_cu_memcpy(cfla, gces->cfla, sizeof(double), GKYL_CU_MEMCPY_D2H);
@@ -148,7 +134,7 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
 
   gkyl_ten_moment_grad_closure_update_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
     *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers,
-     sz_idx, heat_flux->on_dev, rhs->on_dev);
+    heat_flux->on_dev, rhs->on_dev);
 
   // on success, suggest only bigger time-step; (Only way dt can
   // reduce is if the update fails. If the code comes here the update

--- a/moments/zero/ten_moment_grad_closure_cu.cu
+++ b/moments/zero/ten_moment_grad_closure_cu.cu
@@ -47,14 +47,8 @@ create_offsets_centers(const struct gkyl_range *range, long offsets[])
 }
 
 __global__ static void 
-gkyl_ten_moment_grad_closure_set_cu_dev_ptrs(gkyl_ten_moment_grad_closure *gces,
-  struct gkyl_rect_grid grid, double k0, double cfl)
+gkyl_ten_moment_grad_closure_set_cu_dev_ptrs(gkyl_ten_moment_grad_closure *gces)
 {
-  gces->grid = grid;
-  gces->ndim = grid.ndim;
-  gces->k0 = k0;
-  gces->cfl = cfl;
-
   grad_closure_calc_q_choose(gces);
   grad_closure_update_q_choose(gces);
 }
@@ -123,31 +117,17 @@ gkyl_ten_moment_grad_closure_update_cu_ker(const gkyl_ten_moment_grad_closure *g
 }
 
 gkyl_ten_moment_grad_closure*
-gkyl_ten_moment_grad_closure_cu_dev_new(struct gkyl_ten_moment_grad_closure_inp inp)
+gkyl_ten_moment_grad_closure_cu_dev_new(gkyl_ten_moment_grad_closure *gces)
 {
-  gkyl_ten_moment_grad_closure *gces = (gkyl_ten_moment_grad_closure*)
-    gkyl_malloc(sizeof(gkyl_ten_moment_grad_closure));
-
-  gces->cfla = (double*) gkyl_cu_malloc(sizeof(double));
-
-  struct gkyl_null_comm_inp null = { };
-  
-  if (inp.comm)
-    gces->comm = gkyl_comm_acquire(inp.comm);
-  else
-    gces->comm = gkyl_null_comm_inew( &null );
-
   // copy the host struct to device struct
   gkyl_ten_moment_grad_closure *gces_cu = (gkyl_ten_moment_grad_closure*)
     gkyl_cu_malloc(sizeof(gkyl_ten_moment_grad_closure));
   gkyl_cu_memcpy(gces_cu, gces, sizeof(gkyl_ten_moment_grad_closure),
     GKYL_CU_MEMCPY_H2D);
 
-  gkyl_ten_moment_grad_closure_set_cu_dev_ptrs<<<1,1>>>(gces_cu, *(inp.grid),
-    inp.k0, inp.cfl);
+  gkyl_ten_moment_grad_closure_set_cu_dev_ptrs<<<1,1>>>(gces_cu);
   
-  gces->on_dev = gces_cu; // CPU obj points to itself
-  return gces;
+  return gces_cu;
 }
 
 struct gkyl_ten_moment_grad_closure_status
@@ -193,7 +173,8 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
   // compute actual CFL, status & max-speed across all domains
   double red_vars[2] = { cfla[0], is_cfl_violated };
   double red_vars_global[2] = { 0.0, 0.0 };
-  gkyl_comm_allreduce(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars, &red_vars_global);
+  gkyl_comm_allreduce_host(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars,
+    &red_vars_global);
 
   cfla[0] = red_vars_global[0];
   is_cfl_violated = red_vars_global[1];

--- a/moments/zero/ten_moment_grad_closure_cu.cu
+++ b/moments/zero/ten_moment_grad_closure_cu.cu
@@ -10,42 +10,6 @@ extern "C" {
 #include <gkyl_ten_moment_grad_closure_priv.h>
 }
 
-static void
-create_offsets_vertices(const struct gkyl_range *range, long offsets[])
-{
-  int arr1[3] = { -1, -1, -1 }, arr2[3] = { 0, 0, 0 };
-
-  // box spanning stencil
-  struct gkyl_range box3;
-  gkyl_range_init(&box3, range->ndim, arr1, arr2);
-
-  struct gkyl_range_iter iter3;
-  gkyl_range_iter_init(&iter3, &box3);
-
-  // construct list of offsets
-  int count = 0;
-  while (gkyl_range_iter_next(&iter3))
-    offsets[count++] = gkyl_range_offset(range, iter3.idx);
-}
-
-static void
-create_offsets_centers(const struct gkyl_range *range, long offsets[])
-{
-  int arr1[3] = { -1, -1, -1 }, arr2[3] = { 0, 0, 0 };
-
-  // box spanning stencil
-  struct gkyl_range box3;
-  gkyl_range_init(&box3, range->ndim, arr1, arr2);
-
-  struct gkyl_range_iter iter3;
-  gkyl_range_iter_init(&iter3, &box3);
-
-  // construct list of offsets
-  int count = 0;
-  while (gkyl_range_iter_next(&iter3))
-    offsets[count++] = gkyl_range_offset(range, iter3.idx);
-}
-
 __global__ static void 
 gkyl_ten_moment_grad_closure_set_cu_dev_ptrs(gkyl_ten_moment_grad_closure *gces)
 {
@@ -155,13 +119,16 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
 
   long offsets_centers[sz_idx];
   create_offsets_centers(heat_flux_range, offsets_centers);
-  
+
+  gkyl_cu_memcpy(gces->offsets_vertices, offsets_vertices, sizeof(long)*sz_idx, GKYL_CU_MEMCPY_H2D);
+  gkyl_cu_memcpy(gces->offsets_centers, offsets_centers, sizeof(long)*sz_idx, GKYL_CU_MEMCPY_H2D);
+
   gkyl_ten_moment_grad_closure_calc_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
-    *heat_flux_range, *update_range, offsets_vertices, offsets_centers, sz_idx,
+    *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers, sz_idx,
     fluid->on_dev, em_tot->on_dev, cflrate->on_dev, dt, heat_flux->on_dev);
 
   gkyl_ten_moment_grad_closure_update_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
-    *heat_flux_range, *update_range, offsets_vertices, offsets_centers, sz_idx,
+    *heat_flux_range, *update_range, gces->offsets_vertices, gces->offsets_centers, sz_idx,
      heat_flux->on_dev, rhs->on_dev);
 
   gkyl_array_reduce(gces->cfla, cflrate, GKYL_MAX);

--- a/moments/zero/ten_moment_grad_closure_cu.cu
+++ b/moments/zero/ten_moment_grad_closure_cu.cu
@@ -1,0 +1,218 @@
+/* -*- c++ -*- */
+extern "C" {
+#include <float.h>
+
+#include <gkyl_alloc.h>
+#include <gkyl_array_ops.h>
+#include <gkyl_array_reduce.h>
+#include <gkyl_null_comm.h>
+#include <gkyl_ten_moment_grad_closure.h>
+#include <gkyl_ten_moment_grad_closure_priv.h>
+}
+
+static void
+create_offsets_vertices(const struct gkyl_range *range, long offsets[])
+{
+  int arr1[3] = { -1, -1, -1 }, arr2[3] = { 0, 0, 0 };
+
+  // box spanning stencil
+  struct gkyl_range box3;
+  gkyl_range_init(&box3, range->ndim, arr1, arr2);
+
+  struct gkyl_range_iter iter3;
+  gkyl_range_iter_init(&iter3, &box3);
+
+  // construct list of offsets
+  int count = 0;
+  while (gkyl_range_iter_next(&iter3))
+    offsets[count++] = gkyl_range_offset(range, iter3.idx);
+}
+
+static void
+create_offsets_centers(const struct gkyl_range *range, long offsets[])
+{
+  int arr1[3] = { -1, -1, -1 }, arr2[3] = { 0, 0, 0 };
+
+  // box spanning stencil
+  struct gkyl_range box3;
+  gkyl_range_init(&box3, range->ndim, arr1, arr2);
+
+  struct gkyl_range_iter iter3;
+  gkyl_range_iter_init(&iter3, &box3);
+
+  // construct list of offsets
+  int count = 0;
+  while (gkyl_range_iter_next(&iter3))
+    offsets[count++] = gkyl_range_offset(range, iter3.idx);
+}
+
+__global__ static void 
+gkyl_ten_moment_grad_closure_set_cu_dev_ptrs(gkyl_ten_moment_grad_closure *gces,
+  struct gkyl_rect_grid grid, double k0, double cfl)
+{
+  gces->grid = grid;
+  gces->ndim = grid.ndim;
+  gces->k0 = k0;
+  gces->cfl = cfl;
+
+  grad_closure_calc_q_choose(gces);
+  grad_closure_update_q_choose(gces);
+}
+
+__global__ static void
+gkyl_ten_moment_grad_closure_calc_cu_ker(const gkyl_ten_moment_grad_closure *gces,
+  const struct gkyl_range heat_flux_range, const struct gkyl_range update_range,
+  long *offsets_vertices, long *offsets_centers, int sz_idx,
+  const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
+  struct gkyl_array *cflrate, double dt, struct gkyl_array *heat_flux)
+{
+  const double* fluid_d[8];
+  const double* em_tot_d[8];
+  double *heat_flux_d;
+
+  int vidx[GKYL_MAX_DIM];
+
+  for(unsigned long linc = threadIdx.x + blockIdx.x*blockDim.x;
+      linc < heat_flux_range.volume; linc += blockDim.x*gridDim.x) {
+
+    gkyl_sub_range_inv_idx(&heat_flux_range, linc, vidx);
+
+    long linc_vertex = gkyl_range_idx(&heat_flux_range, vidx);
+    long linc_center = gkyl_range_idx(&update_range, vidx);
+
+    for (int i=0; i<sz_idx; ++i) {
+      em_tot_d[i] =  (const double*) gkyl_array_cfetch(em_tot,
+        linc_center + offsets_vertices[i]);
+      fluid_d[i] = (const double*) gkyl_array_cfetch(fluid,
+        linc_center + offsets_vertices[i]);
+    }
+
+    heat_flux_d = (double*) gkyl_array_fetch(heat_flux, linc_vertex);
+    double *cflr = (double*) gkyl_array_fetch(cflrate, linc_center);
+
+    gces->calc_q(gces, fluid_d, cflr, dt, heat_flux_d);
+  }
+}
+
+__global__ static void
+gkyl_ten_moment_grad_closure_update_cu_ker(const gkyl_ten_moment_grad_closure *gces,
+  const struct gkyl_range heat_flux_range, const struct gkyl_range update_range,
+  long *offsets_vertices, long *offsets_centers, int sz_idx,
+  const struct gkyl_array *heat_flux, struct gkyl_array *rhs)
+{
+  const double* heat_flux_up[8];
+  
+  int cidx[GKYL_MAX_DIM];
+
+  for(unsigned long linc = threadIdx.x + blockIdx.x*blockDim.x;
+    linc < update_range.volume; linc += blockDim.x*gridDim.x) {
+
+    gkyl_sub_range_inv_idx(&update_range, linc, cidx);
+
+    long linc_vertex = gkyl_range_idx(&heat_flux_range, cidx);
+    long linc_center = gkyl_range_idx(&update_range, cidx);
+
+    for (int i=0; i<sz_idx; ++i)
+      heat_flux_up[i] = (const double*) gkyl_array_cfetch(heat_flux,
+        linc_vertex + offsets_centers[i]);
+
+    double* rhs_d = (double*) gkyl_array_fetch(rhs, linc_center);
+
+    gces->update_q(gces, heat_flux_up, rhs_d);
+  }
+}
+
+gkyl_ten_moment_grad_closure*
+gkyl_ten_moment_grad_closure_cu_dev_new(struct gkyl_ten_moment_grad_closure_inp inp)
+{
+  gkyl_ten_moment_grad_closure *gces = (gkyl_ten_moment_grad_closure*)
+    gkyl_malloc(sizeof(gkyl_ten_moment_grad_closure));
+
+  gces->cfla = (double*) gkyl_cu_malloc(sizeof(double));
+
+  struct gkyl_null_comm_inp null = { };
+  
+  if (inp.comm)
+    gces->comm = gkyl_comm_acquire(inp.comm);
+  else
+    gces->comm = gkyl_null_comm_inew( &null );
+
+  // copy the host struct to device struct
+  gkyl_ten_moment_grad_closure *gces_cu = (gkyl_ten_moment_grad_closure*)
+    gkyl_cu_malloc(sizeof(gkyl_ten_moment_grad_closure));
+  gkyl_cu_memcpy(gces_cu, gces, sizeof(gkyl_ten_moment_grad_closure),
+    GKYL_CU_MEMCPY_H2D);
+
+  gkyl_ten_moment_grad_closure_set_cu_dev_ptrs<<<1,1>>>(gces_cu, *(inp.grid),
+    inp.k0, inp.cfl);
+  
+  gces->on_dev = gces_cu; // CPU obj points to itself
+  return gces;
+}
+
+struct gkyl_ten_moment_grad_closure_status
+gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces,
+  const struct gkyl_range *heat_flux_range, const struct gkyl_range *update_range,
+  const struct gkyl_array *fluid, const struct gkyl_array *em_tot,
+  struct gkyl_array *cflrate, double dt, struct gkyl_array *heat_flux,
+  struct gkyl_array *rhs)
+{
+  int nblocks = heat_flux_range->nblocks, nthreads = heat_flux_range->nthreads;
+
+  double cfla[1] = { 0.0 }, cfl = 0.0;
+  double is_cfl_violated = 0.0; // deliberately a double
+
+  // gkyl_cu_memcpy(cfl, gces->cfl, sizeof(double), GKYL_CU_MEMCPY_D2H); // probably don't actually need this? Don't think there's any reason for cfl to be needed on device.
+  double cflm = 1.1*gces->cfl;
+
+  int ndim = update_range->ndim;
+  long sz[] = { 2, 4, 8 };
+
+  int sz_idx = sz[ndim-1];
+
+  long offsets_vertices[sz_idx];
+  create_offsets_vertices(update_range, offsets_vertices);
+
+  long offsets_centers[sz_idx];
+  create_offsets_centers(heat_flux_range, offsets_centers);
+  
+  gkyl_ten_moment_grad_closure_calc_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
+    *heat_flux_range, *update_range, offsets_vertices, offsets_centers, sz_idx,
+    fluid->on_dev, em_tot->on_dev, cflrate->on_dev, dt, heat_flux->on_dev);
+
+  gkyl_ten_moment_grad_closure_update_cu_ker<<<nblocks, nthreads>>>(gces->on_dev,
+    *heat_flux_range, *update_range, offsets_vertices, offsets_centers, sz_idx,
+     heat_flux->on_dev, rhs->on_dev);
+
+  gkyl_array_reduce(gces->cfla, cflrate, GKYL_MAX);
+  gkyl_cu_memcpy(cfla, gces->cfla, sizeof(double), GKYL_CU_MEMCPY_D2H);
+
+  if (cfla[0] > cflm)
+    is_cfl_violated = 1.0;
+
+  // compute actual CFL, status & max-speed across all domains
+  double red_vars[2] = { cfla[0], is_cfl_violated };
+  double red_vars_global[2] = { 0.0, 0.0 };
+  gkyl_comm_allreduce(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars, &red_vars_global);
+
+  cfla[0] = red_vars_global[0];
+  is_cfl_violated = red_vars_global[1];
+
+  double dt_suggested = dt*cfl/fmax(cfla[0], DBL_MIN);
+
+  if (is_cfl_violated > 0.0)
+    // indicate failure, and return smaller stable time-step
+    return (struct gkyl_ten_moment_grad_closure_status) {
+      .success = 0,
+      .dt_suggested = dt_suggested,
+    };
+
+  // on success, suggest only bigger time-step; (Only way dt can
+  // reduce is if the update fails. If the code comes here the update
+  // succeeded and so we should not allow dt to reduce).
+  return (struct gkyl_ten_moment_grad_closure_status) {
+    .success = is_cfl_violated > 0.0 ? 0 : 1,
+    .dt_suggested = dt_suggested > dt ? dt_suggested : dt,
+  };
+
+}

--- a/moments/zero/ten_moment_grad_closure_cu.cu
+++ b/moments/zero/ten_moment_grad_closure_cu.cu
@@ -104,7 +104,6 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
   int nblocks = heat_flux_range->nblocks, nthreads = heat_flux_range->nthreads;
 
   double cfla[1] = { 0.0 }, cfl = 0.0;
-  double is_cfl_violated = 0.0; // deliberately a double
 
   // gkyl_cu_memcpy(cfl, gces->cfl, sizeof(double), GKYL_CU_MEMCPY_D2H); // probably don't actually need this? Don't think there's any reason for cfl to be needed on device.
   double cflm = 1.1*gces->cfl;
@@ -130,21 +129,17 @@ gkyl_ten_moment_grad_closure_advance_cu(const gkyl_ten_moment_grad_closure *gces
   gkyl_array_reduce(gces->cfla, cflrate, GKYL_MAX);
   gkyl_cu_memcpy(cfla, gces->cfla, sizeof(double), GKYL_CU_MEMCPY_D2H);
 
-  if (cfla[0] > cflm)
-    is_cfl_violated = 1.0;
-
   // compute actual CFL, status & max-speed across all domains
-  double red_vars[2] = { cfla[0], is_cfl_violated };
-  double red_vars_global[2] = { 0.0, 0.0 };
+  double red_vars[1] = { cfla[0] };
+  double red_vars_global[1] = { 0.0 };
   gkyl_comm_allreduce_host(gces->comm, GKYL_DOUBLE, GKYL_MAX, 2, &red_vars,
     &red_vars_global);
 
   cfla[0] = red_vars_global[0];
-  is_cfl_violated = red_vars_global[1];
-
+  
   double dt_suggested = dt*cfl/fmax(cfla[0], DBL_MIN);
 
-  if (is_cfl_violated > 0.0)
+  if (cfla[0] > cflm)
     // indicate failure, and return smaller stable time-step
     return (struct gkyl_ten_moment_grad_closure_status) {
       .success = 0,


### PR DESCRIPTION
The gradient closure code compiles and runs without crashing on GPUs. The implicit source update is not yet on GPU, so the code segfaults soon after this calculation. Results will need to me checked more carefully once the source update is finished, but heat flux directions at least quantitatively look correct.

Also, added a check for the `is_static` flag into `mom_species`, to allow for running only the source update in simulations.